### PR TITLE
Adds a link to HA-Dockermon for Docker users

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ _Valuable links, that don't fit in any of the above categories (yet!)._
 * [Developer Documentation](https://developers.home-assistant.io/) - The official developer documentation.
 * [HASS Configurator](https://github.com/danielperna84/hass-configurator) - Browser-based configuration file editor.
 * [Home Assistant Podcast](https://hasspodcast.io) - Biweekly Podcast with the latest news and interesting guests.
-* [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS service for RESTful switches to control docker containers.
+* [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS service for RESTful switches to control Docker containers.
 
 ## Alternative Home Automation Software
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ _Valuable links, that don't fit in any of the above categories (yet!)._
 * [Developer Documentation](https://developers.home-assistant.io/) - The official developer documentation.
 * [HASS Configurator](https://github.com/danielperna84/hass-configurator) - Browser-based configuration file editor.
 * [Home Assistant Podcast](https://hasspodcast.io) - Biweekly Podcast with the latest news and interesting guests.
-* [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS app designed to work with Home Assistant RESTful switches to control docker containers.
+* [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS service for RESTful switches to control docker containers.
 
 ## Alternative Home Automation Software
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ _Valuable links, that don't fit in any of the above categories (yet!)._
 * [Developer Documentation](https://developers.home-assistant.io/) - The official developer documentation.
 * [HASS Configurator](https://github.com/danielperna84/hass-configurator) - Browser-based configuration file editor.
 * [Home Assistant Podcast](https://hasspodcast.io) - Biweekly Podcast with the latest news and interesting guests.
+* [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS app designed to work with Home Assistant RESTful switches to control docker containers.
 
 ## Alternative Home Automation Software
 


### PR DESCRIPTION
# Describe the proposed change

Adds a link to the HA Dockermon repo which allows users to start
stop and control docker containers from within Home Assistant.

## The link

https://github.com/philhawthorne/ha-dockermon

## The annoying "I agree" thing

- [X] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [X] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
