### PR TITLE
Add selfhostedhome.com to list of blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ _Links to various users of Home Assistant that regularly publish Home Assistant 
 * [DIY Futurism](https://diyfuturism.com/) - Brad posts articles with great instructions for new users.
 * [Phil Hawthorne](https://philhawthorne.com/homeautomation) - Co-host of the Home Assistant Podcast.
 * [Smart Home Hobby](https://smarthomehobby.com/) - Features budget friendly guides and information.
+* [Self Hosted Home](https://selfhostedhome.com/) - Articles on Home Assistant and other Self Hosted applications.
 
 ### YouTube Channels
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ _Links to various users of Home Assistant that regularly publish Home Assistant 
 * [DIY Futurism](https://diyfuturism.com/) - Brad posts articles with great instructions for new users.
 * [Phil Hawthorne](https://philhawthorne.com/homeautomation) - Co-host of the Home Assistant Podcast.
 * [Smart Home Hobby](https://smarthomehobby.com/) - Features budget friendly guides and information.
-* [Self Hosted Home](https://selfhostedhome.com/) - Articles on Home Assistant and other Self Hosted applications.
+* [Self Hosted Home](https://selfhostedhome.com/) - Articles on DIY home automation projects and self hosted services.
 
 ### YouTube Channels
 


### PR DESCRIPTION
# Describe the proposed change

I've recently started a blog that I think would be useful on this list. It includes some articles on Home Assistant as well as other "Self Hosted" applications

## The link

https://selfhostedhome.com

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
