### PR TITLE
Adds Dropbox Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _Anyone could create an add-on, the following are created by the community._
 * [Octobox](https://github.com/hassio-addons/addon-octobox) - Take back control of your GitHub notifications.
 * [Aircast](https://github.com/hassio-addons/addon-aircast) - AirPlay capabilities for your Chromecast players.
 * [AirSonos](https://github.com/hassio-addons/addon-airsonos) - AirPlay capabilities for your Sonos players.
+* [Dropbox Sync](https://github.com/danielwelch/hassio-dropbox-sync) - Upload your backup snapshots to Dropbox.
 
 ## User Interface
 


### PR DESCRIPTION
# Describe the proposed change

Adds Dropbox Sync.

Upload your Hass.io backup snapshots to Dropbox.

This add-on allows you to upload your Hass.io snapshots to your Dropbox, keeping your snapshots safe and available in case of hardware failure. Uploads are triggered via a service call, making it easy to automate periodic backups or trigger uploads to Dropbox via script as you would with any other Home Assistant service.

## The link

https://github.com/danielwelch/hassio-dropbox-sync

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
