### PR TITLE
Add HASSCASTS to the YouTube Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ _Sit back, relax, watch, and learn._
 * [BurnsHA](https://www.youtube.com/channel/UCSKQutOXuNLvFetrKuwudpg) - Great informational and tutorial videos.
 * [DrZzs](https://www.youtube.com/channel/UC7G4tLa4Kt6A9e3hJ-HO8ng) - Great how-to videos and also streams live.
 * [The Hookhup](https://www.youtube.com/channel/UC2gyzKcHbYfqoXA5xbyGXtQ) - Tutorials and more, also has videos on home automation in general.
-* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Home Assistant & Home Automation Tip, Trick & Tutorials, moving to mainly live streams
+* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Home Assistant Tip, Trick & Tutorials, moving to mainly live streams
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ _Sit back, relax, watch, and learn._
 * [BurnsHA](https://www.youtube.com/channel/UCSKQutOXuNLvFetrKuwudpg) - Great informational and tutorial videos.
 * [DrZzs](https://www.youtube.com/channel/UC7G4tLa4Kt6A9e3hJ-HO8ng) - Great how-to videos and also streams live.
 * [The Hook Up](https://www.youtube.com/channel/UC2gyzKcHbYfqoXA5xbyGXtQ) - Tutorials and more, also has videos on home automation in general.
-* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Tip, Trick & Tutorials, moving to mainly live streams.
+* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Tips, Tricks & Tutorials, moving to mainly live streams.
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ _Sit back, relax, watch, and learn._
 * [BurnsHA](https://www.youtube.com/channel/UCSKQutOXuNLvFetrKuwudpg) - Great informational and tutorial videos.
 * [DrZzs](https://www.youtube.com/channel/UC7G4tLa4Kt6A9e3hJ-HO8ng) - Great how-to videos and also streams live.
 * [The Hookhup](https://www.youtube.com/channel/UC2gyzKcHbYfqoXA5xbyGXtQ) - Tutorials and more, also has videos on home automation in general.
+* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Home Assistant & Home Automation Tip, Trick & Tutorials, moving to mainly live streams
 
 ### Podcasts
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ _Sit back, relax, watch, and learn._
 * [BurnsHA](https://www.youtube.com/channel/UCSKQutOXuNLvFetrKuwudpg) - Great informational and tutorial videos.
 * [DrZzs](https://www.youtube.com/channel/UC7G4tLa4Kt6A9e3hJ-HO8ng) - Great how-to videos and also streams live.
 * [The Hook Up](https://www.youtube.com/channel/UC2gyzKcHbYfqoXA5xbyGXtQ) - Tutorials and more, also has videos on home automation in general.
-* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Home Assistant Tip, Trick & Tutorials, moving to mainly live streams
+* [HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ) - Tip, Trick & Tutorials, moving to mainly live streams.
 
 ### Podcasts
 


### PR DESCRIPTION
# Describe the proposed change

The HASSCASTS Channel provides tutorial videos mainly based around Home Assistant. After all the clue is in the acronym
  [H]ome [ASS]istant screen[CASTS]
So far the videos have mainly been for beginner level but my intent is to produce a range of videos from beginner to advanced level. In fact, one of the things I discussed in my live stream was which video I should do next and 2 of the options were a live stream where I create a Hass.io add-on from scratch or a Home Assistant Component live from scratch (both of which would need some research on my part).
I also do product reviews etc.

Due to my physical disabilities, I have had to take a break for a while and now I have returned with a new plan. I am now doing mainly live videos as I do not need to put anywhere near as much production work in there.

  
## The link

[HASSCASTS](https://www.youtube.com/channel/UCGOCeqMJnLvr-5C-ypUw7IQ)

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
