### PR TITLE
Add link to Elasticsearch component

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ _Anyone could create an add-on, the following are created by the community._
 * [AirSonos](https://github.com/hassio-addons/addon-airsonos) - AirPlay capabilities for your Sonos players.
 * [Dropbox Sync](https://github.com/danielwelch/hassio-dropbox-sync) - Upload your backup snapshots to Dropbox.
 * [Log Viewer](https://github.com/hassio-addons/addon-log-viewer) - Browser-based live log viewing utility.
-* [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publish home-assistant events to Elasticsearch.
 
 ## User Interface
 
@@ -220,6 +219,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [Xiaomi Hygrothermo](https://github.com/dolezsa/Xiaomi_Hygrothermo) - Sensor platform for Xiaomi Mijia BT Hygrothermo temperature and humidity sensor.
 * [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Integrates Volkswagen Carnet (requires valid Carnet subscription).
 * [Untapped](https://github.com/custom-components/sensor.untapped) - Connects with your Untapped account.
+* [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publish home-assistant events to Elasticsearch.
 
 ## DIY
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [Xiaomi Hygrothermo](https://github.com/dolezsa/Xiaomi_Hygrothermo) - Sensor platform for Xiaomi Mijia BT Hygrothermo temperature and humidity sensor.
 * [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Integrates Volkswagen Carnet (requires valid Carnet subscription).
 * [Untapped](https://github.com/custom-components/sensor.untapped) - Connects with your Untapped account.
-* [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publish home-assistant events to Elasticsearch.
+* [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch.
 
 ## DIY
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ _Anyone could create an add-on, the following are created by the community._
 * [AirSonos](https://github.com/hassio-addons/addon-airsonos) - AirPlay capabilities for your Sonos players.
 * [Dropbox Sync](https://github.com/danielwelch/hassio-dropbox-sync) - Upload your backup snapshots to Dropbox.
 * [Log Viewer](https://github.com/hassio-addons/addon-log-viewer) - Browser-based live log viewing utility.
+* [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publish home-assistant events to Elasticsearch.
 
 ## User Interface
 


### PR DESCRIPTION
# Describe the proposed change

This adds a link to the Elasticsearch custom component, which allows home-assistant to publish all events (such as state changes) to your Elasticsearch cluster!

## The link

https://github.com/legrego/homeassistant-elasticsearch

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
