### PR TITLE
Update readme to remove deprecated entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,6 @@ _Get inspired, while commuting, doing your morning routine, or at the gym!_
 
 _Valuable links, that don't fit in any of the above categories (yet!)._
 
-* [Home Assistant for Homebridge](https://github.com/home-assistant/homebridge-homeassistant) - A Homebridge plugin for using Siri and HomeKit.
 * [Room Assistant](https://github.com/mKeRix/room-assistant) - A companion client to handle sensors in multiple rooms.
 * [Home Assistant Companion](https://itunes.apple.com/us/app/home-assistant-open-source-home-automation/id1099568401?mt=8) - iPhone/iPad/iOS App to control and monitor your home remotely.
 * [Mi Flora via MQTT daemon](https://github.com/ThomDietrich/miflora-mqtt-daemon) - Collect and transfer Xiaomi Mi Flora plant sensor data via MQTT.


### PR DESCRIPTION
# Describe the proposed change

The HomeAssistant plugin for HomeBridge plugin is deprecated as noted in their readme: https://github.com/home-assistant/homebridge-homeassistant/blob/master/README.md

I don't think users should be directed to use something that might eventually break. Additionally, HomeAssistant has this functionality native now.


**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
