### PR TITLE
Adds missing full stop to link description

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ _Valuable links, that don't fit in any of the above categories (yet!)._
 * [rhasspy](https://github.com/synesthesiam/rhasspy-assistant) - Toolkit for developing custom voice assistants.
 * [Fully Kiosk Browser](https://www.ozerov.de/fully-kiosk-browser/) - Highly configurable Android Kiosk Browser and App Launcher.
 * [Hassio Vagrant](https://github.com/hassio-addons/hassio-vagrant) - Vagrant box original created for developing add-ons.
-* [AppDaemon](https://github.com/home-assistant/appdaemon) - Python Apps for Home Assistant
+* [AppDaemon](https://github.com/home-assistant/appdaemon) - Python Apps for Home Assistant.
 * [Developer Documentation](https://developers.home-assistant.io/) - The official developer documentation.
 * [HASS Configurator](https://github.com/danielperna84/hass-configurator) - Browser-based configuration file editor.
 * [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A NodeJS service for RESTful switches to control Docker containers.


### PR DESCRIPTION
# Describe the proposed change

Adds missing full stop / proper punctuation to a link description (one was missing).
Based on a review by @sindresorhus.

Ref: sindresorhus/awesome#1390

## The link

n/a/

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
