### PR TITLE
Add Twitter section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - gem install awesome_bot
   - gem install danger
 script:
-  - wl=CONTRIBUTING,awesome-ha.com,github.com/frenck/awesome-home-assistant,discord.me
+  - wl=CONTRIBUTING,awesome-ha.com,twitter.com/frenck,github.com/frenck/awesome-home-assistant,discord.me
   - awesome_bot README.md --allow-redirect --white-list $wl
   - danger
 notifications:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ please read the [guide](https://github.com/frenck/awesome-home-assistant/blob/ma
     - [Blogs](#blogs)
     - [YouTube Channels](#youtube-channels)
     - [Podcasts](#podcasts)
-    - [Twitter Accounts](#twitter-accounts)
+    - [Twitter](#twitter)
 - [Uncategorized](#uncategorized)
 - [Alternative Home Automation Software](#alternative-home-automation-software)
 - [Other Awesome Lists](#other-awesome-lists)
@@ -289,17 +289,17 @@ _Get inspired, while commuting, doing your morning routine, or at the gym!_
 
 * [Home Assistant Podcast](https://hasspodcast.io) - Biweekly podcast with the latest news and interesting guests.
 
-### Twitter Accounts
+### Twitter
 
 _Keep up with the latest news and updates, 280 characters at a time!_
 
-* [@home_assistant](https://twitter.com/home_assistant) - Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
-* [@hass_devs](https://twitter.com/hass_devs) - Follow us for the latest news around developing for Home Assistant. Follow the main account at @home_assistant.
-* [@balloob](https://twitter.com/balloob) - Founder Home Assistant. Engineer at Ubiquiti. It's nice to be important but it is more important to be nice.
-* [@ccostan](https://twitter.com/ccostan) - Blogger of all things Tech @ https://vCloudInfo.com . Virtualization, Smart Home, #IOT & other Geeky subjects. Subject Matter Expert in Central FL for IPM. 🏡
+* [@home_assistant](https://twitter.com/home_assistant) - Open source home automation that puts local control and privacy first.
+* [@hass_devs](https://twitter.com/hass_devs) - Latest news on the development of Home Assistant for contributors.
+* [@balloob](https://twitter.com/balloob) - Founder of the Home Assistant project.
+* [@pvizeli](https://twitter.com/pvizeli) - Core developer and creator of the Hass.io project.
+* [@frenck](https://twitter.com/frenck) - Creator of this Awesome list and maintainer of the Community Hass.io Add-ons project.
+* [@ccostan](https://twitter.com/ccostan) - Blogger of all things Tech. Smart Home, #IOT & other Geeky subjects.
 * [@HomeTechHacker](https://twitter.com/HomeTechHacker) - Guy friends call when #tech happens. Tweet 25-50x/week about #smarthome, #homenetwork, #cybersecurity, #Linux, #gadgets, and #life. 
-* [@Atomic_HA](https://twitter.com/Atomic_HA) - I'm a house in San Antonio, TX and my brain is provided by @home_assistant. I like to tweet about the things I do for my family and I CHIRP for new followers!
-* [@BearStoneHA](https://twitter.com/BearStoneHA) - I'm a Smart House full of #IOT. @CCostan & family live in me. I'm powered by @Home_Assistant and @Tesla. #SmartHome #HomeAutomation #Bot.
 
 ## Uncategorized
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ please read the [guide](https://github.com/frenck/awesome-home-assistant/blob/ma
     - [Blogs](#blogs)
     - [YouTube Channels](#youtube-channels)
     - [Podcasts](#podcasts)
+    - [Twitter Accounts](#twitter-accounts)
 - [Uncategorized](#uncategorized)
 - [Alternative Home Automation Software](#alternative-home-automation-software)
 - [Other Awesome Lists](#other-awesome-lists)
@@ -287,6 +288,18 @@ _Sit back, relax, watch, and learn._
 _Get inspired, while commuting, doing your morning routine, or at the gym!_
 
 * [Home Assistant Podcast](https://hasspodcast.io) - Biweekly podcast with the latest news and interesting guests.
+
+### Twitter Accounts
+
+_Keep up with the latest news and updates, 280 characters at a time!_
+
+* [@home_assistant](https://twitter.com/home_assistant) - Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts.
+* [@hass_devs](https://twitter.com/hass_devs) - Follow us for the latest news around developing for Home Assistant. Follow the main account at @home_assistant.
+* [@balloob](https://twitter.com/balloob) - Founder Home Assistant. Engineer at Ubiquiti. It's nice to be important but it is more important to be nice.
+* [@ccostan](https://twitter.com/ccostan) - Blogger of all things Tech @ https://vCloudInfo.com . Virtualization, Smart Home, #IOT & other Geeky subjects. Subject Matter Expert in Central FL for IPM. 🏡
+* [@HomeTechHacker](https://twitter.com/HomeTechHacker) - Guy friends call when #tech happens. Tweet 25-50x/week about #smarthome, #homenetwork, #cybersecurity, #Linux, #gadgets, and #life. 
+* [@Atomic_HA](https://twitter.com/Atomic_HA) - I'm a house in San Antonio, TX and my brain is provided by @home_assistant. I like to tweet about the things I do for my family and I CHIRP for new followers!
+* [@BearStoneHA](https://twitter.com/BearStoneHA) - I'm a Smart House full of #IOT. @CCostan & family live in me. I'm powered by @Home_Assistant and @Tesla. #SmartHome #HomeAutomation #Bot.
 
 ## Uncategorized
 


### PR DESCRIPTION
# Describe the proposed change

Adds a section for Twitter Accounts related to Home Assistant. Twitter is another channel for many people to keep up with news and hobbies, and there are many users on Twitter who tweet about home assistant or home automation in general.

## The link

Several accounts were included in the new section.

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
