### PR TITLE
🔥Remove custom_component sensor.versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ _Additional components for Home Assistant, that were created by the community._
 * [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Integrates Volkswagen Carnet (requires valid Carnet subscription).
 * [Untappd](https://github.com/custom-components/sensor.untapped) - Connects with your Untappd account.
 * [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch.
-* [Versions](https://github.com/custom-components/sensor.versions) - A sensor that fetches the version number of current releases.
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

Remove the link to the custom_component `sensor.versions`

From version 0.82.0 of Home Assistant the functionality of this custom_component are now part of the `sensor.version` platform.

The custom_component repo has been deprecated and archived.


## The link(s)

- https://github.com/custom-components/sensor.versions
- https://www.home-assistant.io/blog/2018/11/09/release-82/#
- https://www.home-assistant.io/components/sensor.version/
-https://github.com/home-assistant/home-assistant/commit/3d1a324f33493ba6477e6caf61248a0a6160b7bc#diff-64e9aa4a801299414e592b58c0036b7f


## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
