### PR TITLE
Adds hass-fontawesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ fit your needs or taste better._
 
 * [HA Floorplan](https://github.com/pkozul/ha-floorplan) - Interaction with your entities from a Floorplan.
 * [Custom UI elements](https://github.com/andrey-git/home-assistant-custom-ui) - For use with a (non-Lovelace) frontend.
+* [Font Awesome Icons](https://github.com/thomasloven/hass-fontawesome) - Use the free icons from Font Awesome in your frontend.
 
 ### Themes
 


### PR DESCRIPTION
# Describe the proposed change

Add a link to hass-fontawesome, which allows you to use the Font Awesome icons in your Home Assistant frontend, additionally to the MDI icons.

## The link

https://github.com/thomasloven/hass-fontawesome

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.