### PR TITLE
Added link in the custom components section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Integrates Volkswagen Carnet (requires valid Carnet subscription).
 * [Untappd](https://github.com/custom-components/sensor.untapped) - Connects with your Untappd account.
 * [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch.
+* [Custom components](https://github.com/custom-components) - An organization for community-developed custom components.
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

A link to a github repo for custom components. The link is appended at the bottom of the relevant section, but it could well be put at the top as the linked repo aims at collecting all community-developed components before they get officially integrated into HA.

## The link

https://github.com/custom-components

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
