### PR TITLE
Replace abandoned project with New project (Broadlink IR -> SmartIR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [Google Geocode](https://github.com/michaelmcarthur/GoogleGeocode-HASS) - Converts a device tracker location into a human-readable address.
 * [Lutron Caseta Pro](https://github.com/upsert/lutron-caseta-pro) - Integrates Lutron Caseta Smart Bridge PRO / RA2 Select.
 * [ToonHA](https://github.com/krocat/ToonHA) - Integrates Toon by Eneco using the official API.
-* [Broadlink IR](https://github.com/vpnmaster/homeassistant-custom-components) - Integrates devices using Broadlink IR.
+* [Smart IR](https://github.com/smartHomeHub/SmartIR) - Integrates devices using Broadlink IR (Xiaomi IR to be implemented).
 * [Xiaomi Hygrothermo](https://github.com/dolezsa/Xiaomi_Hygrothermo) - Sensor platform for Xiaomi Mijia BT Hygrothermo temperature and humidity sensor.
 * [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Integrates Volkswagen Carnet (requires valid Carnet subscription).
 * [Untappd](https://github.com/custom-components/sensor.untapped) - Connects with your Untappd account.


### PR DESCRIPTION
Broadlink IR project is now obsolete Smart IR has replaced this functionality (since HA 0.88)

# Describe the proposed change

Removed Broadlink IR - since it is obsolete and replaced the link with an active custom component which replicates the same functionality and is currently maintained 

## The link

https://github.com/smartHomeHub/SmartIR

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
