### PR TITLE
ZyXEL PoE Custom Component - Shameless self promotion [3/3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [Untappd](https://github.com/custom-components/sensor.untapped) - Connects with your Untappd account.
 * [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch.
 * [Sonoff/eWeLink](https://github.com/peterbuga/HASS-sonoff-ewelink) - Control Sonoff/eWeLink smart devices using the stock firmware.
+* [ZyXEL PoE](https://github.com/lukas-hetzenecker/home-assistant-zyxel-poe) - Platform that exposes switches for the Power-over-Ethernet state of ZyXEL network devices (at least GS1900-series switches).
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

Add ZyXEL Power-over-Ethernet custom component. Exposes a switch for every port of the network device.

## The link

https://github.com/lukas-hetzenecker/home-assistant-zyxel-poe

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
