### PR TITLE
Adds hass-aarlo to Custom Components section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [HACS](https://custom-components.github.io/hacs/) - This is a manager for your custom integration (components) and plugin (lovelace elements) needs.
 * [breaking_changes](https://github.com/custom-components/breaking_changes) - Component to show potential breaking_changes in the current published version based on your loaded components.
 * [Circadian Lighting](https://github.com/claytonjn/hass-circadian_lighting) - Circadian Lighting slowly synchronizes your color changing lights with the regular naturally occuring color temperature of the sky throughout the day.
+* [HASS Aarlo](https://github.com/twrecked/hass-aarlo) - Asynchronous Arlo Component for Home Assistant. The component operates in a similar way to the Arlo web site - it opens a single event stream to the Arlo backend and monitors events and state changes for all base stations, cameras and doorbells in a system. 
 
 ## DIY
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ _Additional components for Home Assistant, that were created by the community._
 * [HACS](https://custom-components.github.io/hacs/) - This is a manager for your custom integration (components) and plugin (lovelace elements) needs.
 * [breaking_changes](https://github.com/custom-components/breaking_changes) - Component to show potential breaking_changes in the current published version based on your loaded components.
 * [Circadian Lighting](https://github.com/claytonjn/hass-circadian_lighting) - Circadian Lighting slowly synchronizes your color changing lights with the regular naturally occuring color temperature of the sky throughout the day.
-* [HASS Aarlo](https://github.com/twrecked/hass-aarlo) - Asynchronous Arlo Component for Home Assistant. The component operates in a similar way to the Arlo web site - it opens a single event stream to the Arlo backend and monitors events and state changes for all base stations, cameras and doorbells in a system. 
+* [HASS Aarlo](https://github.com/twrecked/hass-aarlo) - Asynchronous Arlo integration. Similar to the Arlo web site; monitors events and states for all base stations, cameras and doorbells. 
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

Adds hass-aarlo to custom components list.  Hass-Aarlo is an asynchronous Arlo Component for Home Assistant.  The component operates in a similar way to the Arlo web site - it opens a single event stream to the Arlo backend and monitors events and state changes for all base stations, cameras and doorbells in a system.   It is actively developed and is superior to the core component in reliability and feature set.

I've been using it for months now and it is superior in every way to the existing core component adding a number of features and support.

Besides the custom component, hass-aarlo also includes a plugin for Lovelace that displays the camera along with all the sensors and is highly customizable.  Support for HACS to be included in an upcoming release.

## The link

https://github.com/twrecked/hass-aarlo

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
