### PR TITLE
:sparkles: Adds GitHub Actions as CI

### DIFF
--- a/.github/workflows/awesome.yml
+++ b/.github/workflows/awesome.yml
@@ -1,0 +1,14 @@
+name: Awesome CI
+on:
+  - push
+  - pull_request
+  - schedule:
+    - cron: 0 12 * * *
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: max/awesome-lint@1.0.0
+        with:
+          filename: README.md


### PR DESCRIPTION
# Describe the proposed change

Adds GitHub Actions as the CI to use, also replaced all the older tools with the `awesome-lint`.
