### PR TITLE
Add slate theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ _It is all about the looks, apply some style._
 - [Carbon Green](https://community.home-assistant.io/t/share-your-themes/22018/95?u=frenck) - Light carbon theme with green accents by Reua.
 - [20 Great Themes](https://www.juanmtech.com/themes-in-home-assistant/) - 20 Great themes by JuanMTech (includes a guide).
 - [Many Themes, One Repo](https://github.com/maartenpaauw/home-assistant-community-themes/) - 13 Themes in a convenient ZIP file.
+- [Slate](https://github.com/seangreen2/slate_theme) - A dark theme close to the vanila looks from seangreen2.
 
 ### Custom Lovelace UI Cards
 


### PR DESCRIPTION
# Describe the proposed change

I added a link to the slate theme. Its a dark-mode theme very close on the vanilla look and feel.

## The link

https://github.com/seangreen2/slate_theme

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
