### PR TITLE
Add Atomic Calendar Revive

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ easily add to your instance._
 - [Config Template Card](https://github.com/custom-cards/config-template-card) - Allow using templates in Lovelace.
 - [RGB Light Card](https://github.com/bokub/rgb-light-card) - Colorful buttons to control your RGB Lights.
 - [LG WebOS Remote Control](https://github.com/madmicio/LG-WebOS-Remote-Control) - Remote Control for LG TV WebOS.
+- [Atomic Calendar Revive](https://github.com/marksie1988/atomic-calendar-revive) - Calendar card with advanced settings.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
Atomic Calendar Revive is an updated version of the (abandoned) card originally created by atomic7777.

# Describe the proposed change

Adding maintained calendar card as an alternative to similar deprecated / abandoned cards. 

## The link

https://github.com/atomic7777/atomic_calendar/commit/9092874125acb58d1a5475140c5ace41e9a3b279

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
