### PR TITLE
🚑 Fixes Themes Tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ fit your needs or taste better._
 
 _It is all about the looks, apply some style._
 
-- 📺 [Themes Tutorial](https://www.youtube.com/watch?v=h1h8FFy9_Co) - Quick tutorial/example on how to configure themes.
+- 📺 [Themes Tutorial](https://www.youtube.com/watch?v=3Xpd4zB2eRM) - Quick tutorial/example on how to configure themes.
 - [Midnight](https://community.home-assistant.io/t/midnight-theme/28598?u=frenck) - A dark theme by Marcel Hoffs.
 - [Dark Cyan](https://community.home-assistant.io/t/dark-cyan-theme/28594?u=frenck) - A dark theme with cyan accents by Ryoen Deprouw.
 - [Grey Night](https://community.home-assistant.io/t/grey-night-theme/30848?u=frenck) - A dark theme with grey accents by ksya.


### PR DESCRIPTION
The Themes Tutorial link was pointing to a Youtube video that is marked as private.
This change updates this to point to JuanMTech's tutorial.

Note that this is the same video that is shown in the *20 Great Themes* blogpost from JuanMTech that is mentioned further down the list, so technically there's some duplication here.

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).

