### PR TITLE
Adding Home Assistant Desktop to Uncategorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ _Valuable links, that don't fit in any of the above categories (yet!)._
 - [HASS-data-detective](https://github.com/robmarkcole/HASS-data-detective) - Explore and analyse your database data.
 - [ADB Intents](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304) - List of ADB intents to control Android Devices.
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editting your configuration.
+- [Home Assistant Desktop](https://github.com/mrvnklm/homeassistant-desktop) - A desktop / tray application for quick and easy access from Windows, Mac and Linux.
 
 ## Alternative Home Automation Software
 


### PR DESCRIPTION
# Describe the proposed change

Adding Home Assistant Desktop application, which is a small app / wrapper providing easy and flexible access to one or multiple HA instances from your tray or desktop.

## The link

https://github.com/mrvnklm/homeassistant-desktop

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
