### PR TITLE
Added ll_notify in the Lovelace section

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ easily add to your instance._
 - [RGB Light Card](https://github.com/bokub/rgb-light-card) - Colorful buttons to control your RGB Lights.
 - [LG WebOS Remote Control](https://github.com/madmicio/LG-WebOS-Remote-Control) - Remote Control for LG TV WebOS.
 - [Restriction Card](https://github.com/iantrich/restriction-card) - A card to provide restrictions on Lovelace cards defined within.
+- [ll_notify](https://github.com/rr326/ha_ll_notify) - A component that adds notifications and alerts to Lovelace.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
Note - ll_notify is a *component* but it adds front-end functionality just like a card, so I think it should be listed in the Lovelace section, even though technically not a card.

# Describe the proposed change
ll_notify is a *component* but it adds front-end functionality just like a card, so I think it should be listed in the Lovelace section, even though technically not a card. I'm afraid that if listed as a component, front-end users won't see it.

Why awesome? Once you install in the backend as a component, you can have any button, script, automation, whatever trigger a good looking notification / toast on the front end. And it's fully configurable - different colors, auto-clear timing, etc. It's pretty awesome.

## The link

https://github.com/rr326/ha_ll_notify
## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
