### PR TITLE
✨ Add Vacuum Card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ easily add to your instance._
 - [RGB Light Card](https://github.com/bokub/rgb-light-card) - Colorful buttons to control your RGB Lights.
 - [LG WebOS Remote Control](https://github.com/madmicio/LG-WebOS-Remote-Control) - Remote Control for LG TV WebOS.
 - [Restriction Card](https://github.com/iantrich/restriction-card) - A card to provide restrictions on Lovelace cards defined within.
+- [Vacuum Card](https://github.com/denysdovhan/vacuum-card) — A card to card for controlling a vacuum cleaner robot.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
# Describe the proposed change

This PR adds a card I created for my vacuum cleaner since HA doesn't provide any vacuum card by default. My card has got some attention over time (300+ stars), so I've decided to add it here as well.

## The link

https://github.com/denysdovhan/vacuum-card

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
