### PR TITLE
Add Xiaomi Miot to custom components

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ _Additional components for Home Assistant, that were created by the community._
 - [Circadian Lighting](https://github.com/claytonjn/hass-circadian_lighting) - Circadian Lighting slowly synchronizes your color changing lights with the regular naturally occuring color temperature of the sky throughout the day.
 - [HASS Aarlo](https://github.com/twrecked/hass-aarlo) - Asynchronous Arlo integration. Similar to the Arlo web site; monitors events and states for all base stations, cameras and doorbells.
 - [Xiaomi Cloud Map Extractor](https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor) - This custom integration provides a way to present a live view of a map for a Xiaomi (and Roborock) vacuums without a need for rooting.
+- [Xiaomi Miot](https://github.com/al-one/hass-xiaomi-miot) - Automatic integrate all Xiaomi devices via miot-spec, support Wi-Fi, BLE, ZigBee devices.
 
 ## DIY
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ _Additional components for Home Assistant, that were created by the community._
 - [Circadian Lighting](https://github.com/claytonjn/hass-circadian_lighting) - Circadian Lighting slowly synchronizes your color changing lights with the regular naturally occuring color temperature of the sky throughout the day.
 - [HASS Aarlo](https://github.com/twrecked/hass-aarlo) - Asynchronous Arlo integration. Similar to the Arlo web site; monitors events and states for all base stations, cameras and doorbells.
 - [Xiaomi Cloud Map Extractor](https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor) - This custom integration provides a way to present a live view of a map for a Xiaomi (and Roborock) vacuums without a need for rooting.
-- [Xiaomi Miot](https://github.com/al-one/hass-xiaomi-miot) - Automatic integrate all Xiaomi devices via miot-spec, support Wi-Fi, BLE, ZigBee devices.
+- [Xiaomi Miot](https://github.com/al-one/hass-xiaomi-miot) - Automatic integrate Xiaomi devices via miot-spec, support Wi-Fi, BLE, ZigBee devices.
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

Automatic integrate Xiaomi devices to via miot-spec, support Wi-Fi, BLE, ZigBee devices.

## The link

[Xiaomi Miot](https://github.com/al-one/hass-xiaomi-miot)

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/master/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/master/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
