### PR TITLE
Add expander custom card

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ which you can easily add to your instance._
 - [Vacuum Card](https://github.com/denysdovhan/vacuum-card) - A card to card for controlling a vacuum cleaner robot.
 - [Purifier Card](https://github.com/denysdovhan/purifier-card) - A card for controlling air purifiers.
 - [Raspberry Pi Status Card](https://github.com/ironsheep/lovelace-rpi-monitor-card) - Show status of your Raspberry Pis.
+- [Expander Card](https://github.com/Alia5/lovelace-expander-card) - A expandable/collapsible card with many options.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
# Describe the proposed change

Add link to Expander Card.

_Note on the contribution guidelines:_  
Even though this is shameless self-promotion, I was shocked that there was no (good) expandable/collapsible card available even though there are many feature requests for it.  
I do think that this is a very useful and awesome tool for creating nice dashboards, hence I wanted to include it here as well

## The link

[Add the link here.](https://github.com/Alia5/lovelace-expander-card)

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
