### PR TITLE
Add Dreame Vacuum custom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ _Additional integrations for Home Assistant, that were created by the community.
 - [Sonoff LAN](https://github.com/AlexxIT/SonoffLAN) - Control Sonoff devices with eWeLink (original) firmware over LAN and/or Cloud.
 - [Spotcast](https://github.com/fondberg/spotcast) - Start Spotify playback on an idle Chromecast device as well as control Spotify connect devices.
 - [The Watchman](https://github.com/dummylabs/thewatchman) - Keep track of missing entities and services in your config files.
+- [Dreame Vacuum](https://github.com/Tasshack/dreame-vacuum) - Integration for Dreame robot vacuums with live and saved map support.
 
 ## DIY
 


### PR DESCRIPTION
# Describe the proposed change

_Add link to Dreame Vacuum custom component._
Integration provides live and multi-floor saved maps with every possible setting in the official mobile app as automatically generated entities.
Currently there is not other viable integration that provides full control of the newer Dreame robot vacuums.

## The link

[https://github.com/Tasshack/dreame-vacuum](https://github.com/Tasshack/dreame-vacuum)

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
