### PR TITLE
Add "Mushroom Dashboard Strategy" to Alternative Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ which you can easily add to your instance._
 
 - [TileBoard](https://github.com/resoai/TileBoard) - A simple yet highly configurable Dashboard.
 - [Dwains Dashboard](https://github.com/dwainscheeren/dwains-lovelace-dashboard) - An fully auto-generating dashboard for desktop, tablet and mobile.
+- [Mushroom Dashboard Strategy](https://github.com/AalianKhan/mushroom-strategy) -  A strategy to automatically generate a dashboard using mushroom cards.
 
 ## Custom Integrations
 


### PR DESCRIPTION
# Describe the proposed change

Add a "Mushroom Dashboard Strategy" link to "Alternative Dashboards".

## The link

https://github.com/AalianKhan/mushroom-strategy

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
