### PR TITLE
Add Treemap Card to Custom Cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ which you can easily add to your instance._
 - [Vacuum Card](https://github.com/denysdovhan/vacuum-card) - A card to card for controlling a vacuum cleaner robot.
 - [Purifier Card](https://github.com/denysdovhan/purifier-card) - A card for controlling air purifiers.
 - [Raspberry Pi Status Card](https://github.com/ironsheep/lovelace-rpi-monitor-card) - Show status of your Raspberry Pis.
+- [Treemap Card](https://github.com/omachala/ha-treemap-card) - Visualize entities as a treemap with color gradients, sparklines, and support for sensors, lights, and climate.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
Hi! I'd like to add [Treemap Card](https://github.com/omachala/ha-treemap-card) to the Custom Cards section.

**Treemap Card** is a Lovelace card that visualizes entities as a treemap (like Finviz stock heatmaps):
- Rectangle sizes represent relative values, colors indicate status
- Optimized for thousands of entities
- Supports sensors, lights, and climate entities
- Includes sparklines for historical data
- Available in HACS (Default repository)
- 90%+ test coverage, 18 KB gzipped

It fits well alongside Mini Graph Card, Bar Card, and Power Wheel Card as a data visualization option.

Thank you for maintaining this awesome resource!