### PR TITLE
Add Beatify to Custom Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ _Additional integrations for Home Assistant, that were created by the community.
 - [Sonoff LAN](https://github.com/AlexxIT/SonoffLAN) - Control Sonoff devices with eWeLink (original) firmware over LAN and/or Cloud.
 - [Spotcast](https://github.com/fondberg/spotcast) - Start Spotify playback on an idle Chromecast device as well as control Spotify connect devices.
 - [The Watchman](https://github.com/dummylabs/thewatchman) - Keep track of missing entities and services in your config files.
+- [Beatify](https://github.com/mholzi/beatify) - Multiplayer music quiz party game powered by Music Assistant.
 
 ## DIY
 


### PR DESCRIPTION
## Add Beatify

[Beatify](https://github.com/mholzi/beatify) is a multiplayer music quiz party game integration for Home Assistant, powered by Music Assistant.

**Key features:**
- Real-time multiplayer music guessing game
- Supports Spotify, Apple Music, and YouTube Music via Music Assistant
- 100+ curated playlists with rich metadata
- Artist challenges, speed bonuses, and game highlights
- Available via HACS

**Stats:** 41+ stars, actively maintained, growing community.

This addition follows the contribution guidelines — added as the last item in the Custom Integrations section.