### PR TITLE
Add ble-scale-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ could also build them yourself!_
 - [Home Assistant's Hackster.io](https://www.hackster.io/home-assistant?f=1#_=_) - A Hackster channel with multiple DIY projects.
 - [ESP MQTT Digital LEDs](https://github.com/bruhautomation/ESP-MQTT-JSON-Digital-LEDs) - WS2811 LED Stripe for the JSON Light Component from BRUH.
 - [Bed Presence Detection](https://selfhostedhome.com/diy-bed-presence-detection-home-assistant/) - ESP8266 based Bed Presence Detection.
+- [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Reads BLE smart scales (23 brands), calculates body composition, and publishes to MQTT with auto-discovery for all 11 metrics.
 - [NFC Scanner](https://github.com/klaasnicolaas/ha_nfc_scanner) - Build an NFC tag/card scanner with an ESP8266, PN532 and MQTT.
 - [ESP32-Cam Facebox](https://www.dopebuild.com/i-am-sorry-dave-i-am-unable-to-do-that/) - Tie a ESP32-CAM, HA, and Facebox together for a cheap Facial Recog / Home monitoring solution.
 - [RaspiPool](https://github.com/segalion/raspipool) - A cost-effective, easy-to-build, easy-to-use "Swimming-Pool Automation System".

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ could also build them yourself!_
 - [Home Assistant's Hackster.io](https://www.hackster.io/home-assistant?f=1#_=_) - A Hackster channel with multiple DIY projects.
 - [ESP MQTT Digital LEDs](https://github.com/bruhautomation/ESP-MQTT-JSON-Digital-LEDs) - WS2811 LED Stripe for the JSON Light Component from BRUH.
 - [Bed Presence Detection](https://selfhostedhome.com/diy-bed-presence-detection-home-assistant/) - ESP8266 based Bed Presence Detection.
-- [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Reads BLE smart scales (23 brands), calculates body composition, and publishes to MQTT with auto-discovery for all 11 metrics.
+- [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - BLE smart scale bridge with MQTT auto-discovery — 23 scale brands, 11 body composition metrics as sensors, LWT availability. Runs on Raspberry Pi. [Website](https://blescalesync.dev).
 - [NFC Scanner](https://github.com/klaasnicolaas/ha_nfc_scanner) - Build an NFC tag/card scanner with an ESP8266, PN532 and MQTT.
 - [ESP32-Cam Facebox](https://www.dopebuild.com/i-am-sorry-dave-i-am-unable-to-do-that/) - Tie a ESP32-CAM, HA, and Facebox together for a cheap Facial Recog / Home monitoring solution.
 - [RaspiPool](https://github.com/segalion/raspipool) - A cost-effective, easy-to-build, easy-to-use "Swimming-Pool Automation System".


### PR DESCRIPTION
Adds [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) to the DIY Projects section.

A CLI tool that reads BLE smart scales (23 brands), calculates body composition, and publishes to MQTT with auto-discovery for all 11 metrics — sensors appear automatically as a grouped device. Runs on Raspberry Pi with built-in Bluetooth.

**Website**: https://blescalesync.dev