### PR TITLE
Add Span MAIN 40 (Gen3) custom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ _Additional integrations for Home Assistant, that were created by the community.
 - [Sonoff LAN](https://github.com/AlexxIT/SonoffLAN) - Control Sonoff devices with eWeLink (original) firmware over LAN and/or Cloud.
 - [Spotcast](https://github.com/fondberg/spotcast) - Start Spotify playback on an idle Chromecast device as well as control Spotify connect devices.
 - [The Watchman](https://github.com/dummylabs/thewatchman) - Keep track of missing entities and services in your config files.
+- [Span MAIN 40](https://github.com/Griswoldlabs/span-panel-ha) - Integrates Span MAIN 40 (Gen3) smart electrical panels via local gRPC for real-time circuit monitoring.
 
 ## DIY
 


### PR DESCRIPTION
## Proposed Change

Add the Span MAIN 40 (Gen3) custom integration to the Custom Integrations section.

This is the first Home Assistant integration supporting the Span MAIN 40 Gen3 smart electrical panel. The Gen3 replaced the REST API with gRPC, breaking compatibility with existing Span integrations. This integration reverse-engineers the native gRPC protocol for:

- Real-time power/voltage/current monitoring for all circuits
- Breaker state detection (ON/OFF)
- Dual-phase (120V/240V) support
- Local-only — no cloud, no authentication

**Repository:** https://github.com/Griswoldlabs/span-panel-ha
**HACS:** Custom repository (default listing pending — PR #5683 on hacs/default)
**CI:** HACS Action + Hassfest both passing