### PR TITLE
Add PadSpan HA to Custom Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ _Additional integrations for Home Assistant, that were created by the community.
 - [WebRTC Camera](https://github.com/AlexxIT/WebRTC) - View RTSP streams from IP Cameras in real-time through WebRTC or MSE with Pan/Zoom controls.
 - [Sonoff LAN](https://github.com/AlexxIT/SonoffLAN) - Control Sonoff devices with eWeLink (original) firmware over LAN and/or Cloud.
 - [Spotcast](https://github.com/fondberg/spotcast) - Start Spotify playback on an idle Chromecast device as well as control Spotify connect devices.
+- [PadSpan HA](https://github.com/gbroeckling/padspanHA) - Comprehensive BLE room-presence tracking with room-level accuracy, floor plans, 3D maps, calibration tools, and a rich 21-view frontend panel.
 - [The Watchman](https://github.com/dummylabs/thewatchman) - Keep track of missing entities and services in your config files.
 
 ## DIY


### PR DESCRIPTION
## Add PadSpan HA

Adds [PadSpan HA](https://github.com/gbroeckling/padspanHA) to the Custom Integrations section.

**PadSpan HA** is a comprehensive BLE room-presence tracking system for Home Assistant featuring:

- Room-level BLE presence tracking with multi-scanner RSSI triangulation
- Interactive floor plans and 3D stacked map views
- Calibration tools (pin & listen, roam coverage, k-NN fingerprint matching)
- 21 frontend views including Follow (live tag tracker), Overview, Objects, Bluetooth, Maps, Settings, and more
- Distance sensors using path-loss modeling with user-configurable parameters
- Device tracker, binary sensor, and area sensor entities per tracked BLE device
- 11 language translations
- Sample/demo mode for evaluation without hardware

The integration is installed via HACS or manual copy and provides a full HA sidebar panel.