### PR TITLE
Add Groups Visualizer to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ which you can easily add to your instance._
 - [Vacuum Card](https://github.com/denysdovhan/vacuum-card) - A card to card for controlling a vacuum cleaner robot.
 - [Purifier Card](https://github.com/denysdovhan/purifier-card) - A card for controlling air purifiers.
 - [Raspberry Pi Status Card](https://github.com/ironsheep/lovelace-rpi-monitor-card) - Show status of your Raspberry Pis.
+- [Groups Visualizer](https://github.com/leonidostrovski/groups-visualizer) - Visualize your groups, areas, and entity hierarchy as an interactive zoomable graph.
 
 ### Alternative Dashboards
 


### PR DESCRIPTION
Adding Groups Visualizer—a Lovelace custom card available on HACS that renders HA groups, areas, labels and voice aliases as an interactive, zoomable DAG graph.
   GitHub: https://github.com/leonidostrovski/groups-visualizer
 