### PR TITLE
Add Strix to Third Party Add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ _Anyone can create an add-on, the following are created by the community._
 - [Grocy](https://github.com/hassio-addons/addon-grocy) - ERP beyond your fridge! A groceries & household management solution for your home.
 - [EmonCMS](https://github.com/inverse/hassio-addon-emoncms) - A powerful open-source web app for processing, logging, and visualizing energy, temperature, and other environmental data.
 - [CrowdSec](https://github.com/crowdsecurity/home-assistant-addons) - A next-gen collaborative IPS/IDS to protect you from intrusion.
+- [Strix](https://github.com/eduard256/hassio-strix) - Discovers working stream URLs for IP cameras and generates Frigate configs.
 
 ## Dashboards
 


### PR DESCRIPTION
# Describe the proposed change

Add Strix - an IP camera stream discovery add-on. Finds working stream URLs for IP cameras by testing URL patterns from a database of 100,000+ patterns for 67,000 models, and generates ready-to-use Frigate configs.

## The link

https://github.com/eduard256/hassio-strix

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.