### PR TITLE
Add Sendspin Bluetooth Bridge to Third Party Add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ _Anyone can create an add-on, the following are created by the community._
 - [Grocy](https://github.com/hassio-addons/addon-grocy) - ERP beyond your fridge! A groceries & household management solution for your home.
 - [EmonCMS](https://github.com/inverse/hassio-addon-emoncms) - A powerful open-source web app for processing, logging, and visualizing energy, temperature, and other environmental data.
 - [CrowdSec](https://github.com/crowdsecurity/home-assistant-addons) - A next-gen collaborative IPS/IDS to protect you from intrusion.
+- [Sendspin Bluetooth Bridge](https://github.com/trudenboy/sendspin-bt-bridge) - Turn any Bluetooth speaker, headphones, or soundbar into a smart multi-room audio player with Music Assistant integration.
 
 ## Dashboards
 


### PR DESCRIPTION
## What is Sendspin Bluetooth Bridge?

A Home Assistant addon that turns any Bluetooth speaker, headphones, or soundbar into a smart multi-room audio player.

### Key features
- **Multi-room audio** — sample-accurate sync across all rooms via [Sendspin protocol](https://www.sendspin-audio.com/)
- **Music Assistant integration** — each BT device appears as a native MA player
- **AI automations** — Home Assistant turns speakers into smart endpoints
- **Web UI** — scan, pair, configure and monitor from a polished dashboard
- **HA Ingress + SSO** — seamless integration, no extra ports
- **Multi-arch** — aarch64, amd64, armv7

### Links
- **Repository**: https://github.com/trudenboy/sendspin-bt-bridge
- **Landing page**: https://sendspin-bt-bridge.pages.dev/
- **Documentation**: https://trudenboy.github.io/sendspin-bt-bridge/
- **HA Community topic**: https://community.home-assistant.io/t/993762
- **License**: MIT

### Checklist
- [x] Project is open source (MIT license)
- [x] Repository is active and maintained
- [x] Has documentation
- [x] Works as an HA addon
- [x] Description follows the existing format