### PR TITLE
Add C-Gate Web Bridge to Third Party Add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ _Anyone can create an add-on, the following are created by the community._
 - [Grocy](https://github.com/hassio-addons/addon-grocy) - ERP beyond your fridge! A groceries & household management solution for your home.
 - [EmonCMS](https://github.com/inverse/hassio-addon-emoncms) - A powerful open-source web app for processing, logging, and visualizing energy, temperature, and other environmental data.
 - [CrowdSec](https://github.com/crowdsecurity/home-assistant-addons) - A next-gen collaborative IPS/IDS to protect you from intrusion.
+- [C-Gate Web Bridge](https://github.com/dougrathbone/cgateweb-homeassistant) - Bridge Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT with auto-discovery.
 
 ## Dashboards
 


### PR DESCRIPTION
## Add-on

[C-Gate Web Bridge](https://github.com/dougrathbone/cgateweb-homeassistant) — Bridge Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT with auto-discovery.

## What it does

Connects to a [C-Gate](https://updates.clipsal.com/ClipsalSoftwareDownload/mainsite/cis/technical/downloads/index.html) server (Clipsal's C-Bus gateway software) and bridges C-Bus devices to Home Assistant using MQTT Discovery. Supports:

- **Lights** (dimmable, via C-Bus Application 56)
- **Covers** (blinds, shutters, garage doors)
- **Switches and relays**
- **HVAC/climate zones**
- **Trigger groups** (keypads, scenes)
- **PIR sensors**

Features connection pooling, automatic MQTT broker detection from the Mosquitto add-on, and a built-in label editor web UI.

## Links

- **Add-on repository:** https://github.com/dougrathbone/cgateweb-homeassistant
- **Source code:** https://github.com/dougrathbone/cgateweb
- **C-Bus by Clipsal:** https://www.clipsal.com/products/c-bus