### PR TITLE
Add awesome-mac-mini-homeserver to Other Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ interwebs._
 - [awesome-open-iot](https://github.com/Agile-IoT/awesome-open-iot) - Curated list of open source IoT frameworks, libraries and software.
 - [awesome-amazon-alexa](https://github.com/miguelmota/awesome-amazon-alexa#readme) - Curated list of awesome resources for the Amazon Alexa platform.
 - [awesome-mqtt](https://github.com/hobbyquaker/awesome-mqtt#readme) - Curated list of MQTT related stuff.
+- [awesome-mac-mini-homeserver](https://github.com/momenbasel/awesome-mac-mini-homeserver) - Curated list for running Home Assistant and other services on an Apple Silicon Mac mini home server.
 - [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) - Curated list of awesome self hosted software.
 
 ## Contributing


### PR DESCRIPTION
Hi - adding [awesome-mac-mini-homeserver](https://github.com/momenbasel/awesome-mac-mini-homeserver) to the **Other Awesome Lists** section.

It's a curated list for running an Apple Silicon Mac mini as a 24/7 home server. Home Assistant is featured prominently in the Smart Home section alongside Scrypted, Frigate, Matterbridge, python-matter-server, HOOBS, and Z-Wave JS UI - so the overlap with this list is genuinely high and complementary.

- 260+ curated entries, 32 categories
- CC0-1.0 licensed
- awesome-lint compliant, lychee link-check in CI

Thank you for maintaining awesome-home-assistant - it has been a great reference for me over the years.