### PR TITLE
Add Nexus Agent (MCP server for Home Assistant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ _Anyone can create an add-on, the following are created by the community._
 - [Glances](https://github.com/hassio-addons/addon-glances) - A cross-platform system monitoring tool written in Python.
 - [Matrix](https://github.com/hassio-addons/addon-matrix) - A secure and decentralized communication platform.
 - [AdGuard Home](https://github.com/hassio-addons/addon-adguard-home) - A network-wide ad-and-tracker blocking DNS server with parental control.
+- [Nexus Agent](https://github.com/Fistacho/ha-nexus-agent) - MCP server giving AI assistants (Claude, Cursor, VS Code, any MCP client) full control of Home Assistant: 164 tools across 17 domains including automation/script CRUD with traces, blueprints, dashboards, devices, calendar, todo, voice expose, bulk control, real-time WebSocket events, git versioning, add-on/HACS management.
 - [Traccar](https://github.com/hassio-addons/addon-traccar) - Traccar is modern GPS Tracking Platform.
 - [Home Panel](https://github.com/hassio-addons/addon-home-panel) - A touch-compatible web frontend for controlling the home.
 - [Hass.io Google Drive Backup](https://github.com/sabeechen/hassio-google-drive-backup) - A complete and easy to configure solution for backing up your snapshots to Google Drive.


### PR DESCRIPTION
# Describe the proposed change

Add **Nexus Agent** to the *Third Party Add-ons* section.

Nexus Agent is an MCP (Model Context Protocol) server packaged as a Home Assistant add-on. It exposes **164 tools across 17 domains** — full automation/script CRUD with traces, blueprints, dashboards, devices, calendar, todo, voice expose, bulk control, real-time WebSocket events, git versioning, add-on/HACS management — to any MCP client (Claude Code, Claude Desktop, VS Code, Cursor, Windsurf, OpenAI Codex CLI, Gemini CLI).

It ships with a setup web UI that auto-generates ready-to-paste configuration for every supported client, so users go from install to working AI control in under a minute.

## The link

https://github.com/Fistacho/ha-nexus-agent

## The annoying "I agree" thing

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).