### PR TITLE
Add SECURITY.md tailored for an awesome-list

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,106 @@
+# Security policy
+
+Thanks for taking the time to help keep Awesome Home Assistant safe for
+its readers. We take security seriously -- not just for the repository
+itself, but also for the third-party links we curate.
+
+## Reporting a vulnerability
+
+**Please do not file public issues for security reports.**
+
+Use GitHub's private vulnerability reporting instead:
+
+> [Report a vulnerability](https://github.com/frenck/awesome-home-assistant/security/advisories/new)
+
+If you cannot use GitHub for any reason, email
+[security@frenck.dev](mailto:security@frenck.dev) instead. Please use the same
+inbox for follow-up correspondence on a report.
+
+When reporting, please include:
+
+- A clear description of the issue and its impact.
+- The URL or section of the repository involved (e.g. a specific link, a
+  workflow file, or `awesome-ha.com`).
+- Reproduction steps where applicable.
+- Any proof-of-concept material -- screenshots, logs, recordings.
+
+If you would like updates encrypted, attach a PGP key with your first message
+and we will reply in kind.
+
+## What's in scope
+
+Reports are welcome on any of the following:
+
+- **Malicious link contributions** -- a previously-merged link that now
+  resolves to phishing, malware, drive-by downloads, cryptominers, or
+  similarly hostile content.
+- **Compromised upstream targets** -- a project we link to that has been
+  taken over (typo-squat, account compromise, malicious release, hostile
+  fork promoted as the original) and is actively distributing malware to
+  Home Assistant users.
+- **Repository or workflow vulnerabilities** -- supply-chain weaknesses in
+  this repo's own GitHub Actions workflows, build pipeline, or generated
+  site (`awesome-ha.com`).
+- **Account or credential exposure** in the repo (leaked tokens in
+  history, accidental secret exposure, etc.).
+
+## What's out of scope
+
+The following are not handled through this process:
+
+- **Vulnerabilities in linked third-party projects themselves.** Report
+  those upstream to the project's own maintainers; we are not in a
+  position to fix software we do not own. We will, however, remove or
+  flag links once an upstream issue is publicly known.
+- **Vulnerabilities in Home Assistant Core.** Report those to the
+  Home Assistant project at
+  <https://www.home-assistant.io/security/> or
+  [security@home-assistant.io](mailto:security@home-assistant.io).
+- **Dependency advisories** in `requirements.txt` -- those are handled by
+  Renovate / Dependabot and the dependency-review workflow on every PR.
+- **Stale links or 404s** -- those are link rot, not security issues. The
+  weekly link-check workflow files an issue when it spots them.
+- **Style, formatting, or editorial complaints** about linked
+  third-party projects.
+
+## Supported versions
+
+This is a curated list, not a versioned product. Only the `main` branch
+and the rendered site at <https://awesome-ha.com> are supported. If a
+report relates to historical content from a specific commit or release
+tag, please mention the commit SHA explicitly.
+
+| Branch | Supported |
+| ------ | --------- |
+| `main` | Yes |
+| Other  | No  |
+
+## Response timeline
+
+We aim to:
+
+- **Acknowledge** every valid report within **48 hours**.
+- **Provide an initial assessment** within **7 days** of acknowledgement.
+- **Resolve or publish guidance** within **90 days** of the initial
+  report. Some upstream-driven issues may take longer -- if so, we will
+  keep you updated.
+
+If 90 days pass with no resolution, you are welcome to publicly disclose
+the issue at your discretion. We will not pursue legal action against
+researchers who follow this policy in good faith.
+
+## Coordinated disclosure
+
+Once a report is validated:
+
+1. We work to remove or remediate the offending content as quickly as
+   possible. For malicious link contributions this is usually within
+   hours; for upstream-compromise reports it depends on how the upstream
+   project responds.
+2. We may publish a GitHub Security Advisory describing the issue, with
+   credit to the reporter (unless you prefer to remain anonymous).
+3. We may notify directly affected users where reasonably possible -- for
+   example, by pinging the issue tracker of a previously-listed project
+   that was taken over.
+
+Thank you for helping keep this list safe.


### PR DESCRIPTION
Adds `.github/SECURITY.md`. This file did not exist; OpenSSF Scorecard's `Security-Policy` check is currently 0/10 because of that. With this in place, paired with the `scorecard.yml` workflow added in #674, the next Scorecard run should give 10/10 on that specific check.

## Why this isn't just a copy from the python-* fleet

A curated link list has a different threat model than a Python package. There's no library to ship CVEs against. The real risks here are:

1. **Malicious link contributions** — someone slips a phishing/malware/cryptominer URL past review.
2. **Compromised upstream targets** — a previously-good project we link to gets taken over (typo-squat, account compromise) and starts pushing malware to Home Assistant users via HACS or similar.
3. **Repo workflow hygiene** — the standard Scorecard concerns (pinned actions, token perms, etc.) — which the rest of this PR series already addresses.

The text reflects that, rather than the software-package boilerplate.

## What it contains (matches Scorecard's checklist)

| Scorecard signal | Location in file |
|------------------|------------------|
| Live reporting contact (URL + email) | "Reporting a vulnerability" section, with a real GitHub PVR link and `security@frenck.dev` |
| Supported versions table | "Supported versions" — `main` only, with a note about commit-SHA references for historical content |
| Disclosure timeline | "Response timeline" — 48h ack / 7d initial assessment / 90d resolution |
| Out-of-scope section | "What's out of scope" — explicitly excludes upstream issues, HA Core (with redirect), dependency advisories (Renovate/Dependabot), and link rot (link-checker workflow) |
| Coordinated-disclosure language | "Coordinated disclosure" |

## Notes

- Reporting points at GitHub's private vulnerability reporting (PVR) as the primary channel — make sure that's enabled on the repo (Settings → Code security and analysis → Private vulnerability reporting → Enable). The email is the fallback.
- The "What's in scope / out of scope" sections also serve as triage guidance for me when reports come in — most "vulnerability reports" against an awesome list are actually link rot or upstream issues, and this gives reporters a clear pointer to the right tracker before they even submit.
- HA Core security pointer goes to `https://www.home-assistant.io/security/` and `security@home-assistant.io`. Verify those are still the canonical contacts — they were last I checked but you'd know best.

**Stacked on top of [#674](https://github.com/frenck/awesome-home-assistant/pull/674), [#673](https://github.com/frenck/awesome-home-assistant/pull/673), [#672](https://github.com/frenck/awesome-home-assistant/pull/672)**.