### PR TITLE
Add prek pre-commit hooks for local checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,3 +56,53 @@ Typical reasons for deleting links:
 - Deprecated.
 - In case of software: License missing.
 - Dead link.
+
+## Running checks locally
+
+This is optional — every check below also runs in CI on your pull request.
+But running them locally before pushing means you find issues in seconds
+instead of minutes, and your PR turns green on the first try.
+
+### Quick start with `prek`
+
+[`prek`](https://github.com/j178/prek) is a fast Rust reimplementation of
+the original `pre-commit` and runs the same `.pre-commit-config.yaml`.
+Install it via `pipx install prek` (or `cargo install prek`), then:
+
+```sh
+prek install                  # set up the git pre-commit hook
+prek run --all-files          # run every hook against every file once
+```
+
+After that, the hooks run automatically on `git commit`. To run a single
+hook manually:
+
+```sh
+prek run yamllint --all-files
+prek run zizmor --all-files
+prek run codespell --all-files
+```
+
+### Or use upstream `pre-commit`
+
+If you prefer the original Python tool, [`pre-commit`](https://pre-commit.com)
+works with the same config file:
+
+```sh
+pipx install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
+### What the hooks check
+
+- **trailing-whitespace, end-of-file-fixer, mixed-line-ending** —
+  basic file hygiene
+- **check-yaml** — every YAML file parses
+- **check-merge-conflict** — no leftover `<<<<<<<` markers
+- **codespell** — common typos in prose and comments
+- **yamllint** — YAML style consistency for workflow files
+- **zizmor** — workflow security audit (same checks the CI workflow runs)
+
+`awesome-lint` is intentionally **not** in the local hooks — it requires
+Node.js and we already run it in CI on every PR.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+---
+# Run locally with `prek run --all-files` (or `pre-commit run --all-files`).
+# See CONTRIBUTING.md for setup. CI runs the canonical checks separately.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start:
+    present: true
+  line-length:
+    max: 120
+    level: warning
+  truthy:
+    check-keys: false


### PR DESCRIPTION
Adds local pre-commit hooks runnable via [prek](https://github.com/j178/prek) (or upstream `pre-commit`). Modeled on the python-* fleet's setup but tuned for an awesome-list — no Python project tooling, just hygiene and the same workflow security audit CI runs.

## What's added

### `.pre-commit-config.yaml`

Five hook repos, all rev-pinned and Renovate-trackable:

| Hook | What it catches | Runs in CI? |
|------|-----------------|-------------|
| `pre-commit/pre-commit-hooks` (v6.0.0) | trailing whitespace, EOF newline, mixed line endings, broken YAML, leftover merge-conflict markers | No — local-only |
| `codespell-project/codespell` (v2.4.2) | common typos in prose and comments | No — local-only |
| `adrienverge/yamllint` (v1.38.0) | YAML style consistency for workflow files | No — local-only |
| `zizmorcore/zizmor-pre-commit` (v1.24.1) | workflow security audit | Yes — same checks as #678's workflow |

I deliberately left **`awesome-lint`** out — it needs Node.js and is already definitive in CI. No reason to make every contributor maintain a Node toolchain.

### `.yamllint`

Same config used across the python-* fleet:

- `extends: default`
- `line-length: max=120, level=warning` — long action SHA + comment lines naturally hit ~110 chars
- `truthy: check-keys=false` — `on:` in workflow files is a YAML 1.1 truthy keyword that yamllint would otherwise flag

### `.github/CONTRIBUTING.md` — "Running checks locally" section

Explains how to install prek or upstream pre-commit, what each hook checks, and that all of it is optional (CI is still authoritative). The "optional" framing matters because >90% of contributions to this list come from people editing the README directly through the GitHub web UI — they'll never run prek and shouldn't feel like they have to.

## Why prek over `pre-commit`

Same `.pre-commit-config.yaml` works for both — prek is a drop-in replacement. It's just faster (Rust binary, no Python interpreter spinup). I documented both install paths in CONTRIBUTING; users can pick.

## Tradeoff vs the python-* fleet's setup

The python-* fleet uses `language: system` with Poetry-installed tools (e.g. `entry: poetry run zizmor`), which means hooks share the project's pinned dev dep versions. This repo doesn't have a Poetry virtualenv, so I use upstream rev-pinned hook repos instead. Same effect — Renovate keeps the revs current — but no Python project to maintain.

**Stacked on top of [#678](https://github.com/frenck/awesome-home-assistant/pull/678) and the rest of the ci/ stack.**