### PR TITLE
Document acceptance criteria for new entries

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,57 +2,145 @@
 
 Your contributions are always welcome! Thank you for your suggestions! :smiley:
 
-Please note that this project is released with a 
+Please note that this project is released with a
 [Contributor Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
-Contributing is pretty easy, all you need is an GitHub account.
+Contributing is pretty easy, all you need is a GitHub account.
 
 [Just click this link to edit the list, right from your browser](https://github.com/frenck/awesome-home-assistant/edit/main/README.md).
 
-## Guidelines
+## Acceptance criteria
 
-### Link requirements
+Every entry on this list **must** meet the criteria below. Pull requests that
+add or update entries are checked automatically; CI will block PRs that fail
+any hard requirement and post warnings for soft ones.
 
-The site the link targets **MUST BE**:
+### Universal — every entry
 
-- Be widely recommended regardless of personal opinion.
-- Well known or discussed within the Community.
-- Related to Home Assistant OR provide software, tools, and utilities
-  that can be used with Home Assistant.
+- The URL **must** be reachable. Lychee runs on every PR; broken links are
+  rejected.
+- The URL **must** use HTTPS. No plain `http://`.
+- The URL **must not** be a shortener (e.g. `bit.ly`, `t.co`, `goo.gl`,
+  `tinyurl.com`, `ow.ly`, `is.gd`). Shortener services routinely shut down
+  and take their URLs with them — link to the canonical URL instead.
+- The URL **must not** already be listed elsewhere in this README.
+- Common tracking parameters (`utm_*`, `fbclid`, `gclid`, `mc_eid`) **should**
+  be stripped from the URL before submitting. CI will warn if they're present.
+
+### Software entries (GitHub repositories)
+
+Applies to: **Apps** (Official + Third Party), **Custom Integrations**,
+**Dashboards** (Custom Cards, Themes, Alternative Dashboards), **DIY** entries
+that link to a code repository, and **Alternative Home Automation Software**.
+
+The repository **must**:
+
+- Not be archived.
+- Have been pushed to within the last **18 months**.
+- Be at least **6 months old** (created at least 6 months before submission).
+- Have a `README.md` at the repository root.
+- Be released under an [OSI-approved](https://opensource.org/licenses)
+  open-source license. Proprietary, "Other", and source-available licenses
+  (Elastic-2.0, BSL, SSPL, Commons Clause) are not accepted.
+
+The repository **should** mention "Home Assistant" in its `README.md`.
+This is a CI warning, not a blocker — for general-purpose libraries that
+happen to be used by HA integrations the warning can be acknowledged in the
+PR description.
+
+A soft warning is also shown for repositories with **fewer than 10 stars**
+at the time of submission. Submit anyway, but explain in the PR description
+why this niche or new tool meets the "widely recommended" bar.
+
+### HACS-installable entries
+
+Applies to: **Custom Integrations** and **Dashboards › Custom Cards**.
+
+The repository **must** ship a valid `hacs.json` so users can install through
+[HACS](https://hacs.xyz). For Custom Cards / Lovelace plugins this typically
+means:
+
+```json
+{
+  "name": "My Card",
+  "filename": "my-card.js",
+  "render_readme": true
+}
+```
+
+For Custom Integrations, `hacs.json` plus a valid `manifest.json` under
+`custom_components/<domain>/`.
+
+If the project genuinely cannot be HACS-installed (e.g. it's a CLI tool that
+sits alongside HA), it probably belongs in the Uncategorized section, not
+under Custom Integrations.
+
+### Content entries (blogs, podcasts, YouTube channels)
+
+Applies to: **Blogs**, **Podcasts**, **YouTube Channels**.
+
+The publication **must** have a new post / episode / video within the last
+**12 months**. Stale = abandoned for content; if the author resumes, the
+entry can be re-added at that point.
+
+### Section-specific exemptions
+
+- **Public Configurations** — license check waived. Most are personal HA
+  configs without an explicit license; that's expected.
+- **DIY Projects** that link to a forum thread or blog post (not a code
+  repository) — only the universal URL checks apply. The HA-mention check is
+  also waived since the link target isn't a repo.
+- **Other Awesome Lists** — accepts Creative Commons licenses (CC-BY, CC0,
+  CC-BY-SA) in addition to OSI-approved licenses, since these are content
+  curation works rather than software.
+
+### Subjective — manual review
+
+These can't be checked automatically. Reviewers will look for:
+
+- Widely recommended regardless of personal opinion.
+- Well known or discussed within the community.
 - Written in English.
+- Not self-promotion. CI flags PRs where the author's GitHub account matches
+  the linked repository's owner; if that's you, please explain in the PR
+  description why this entry is awesome.
 
-Self-promotion is frowned upon, so please consider seriously whether your
-project meets the criteria before opening a pull request, otherwise, it may
-be closed without being reviewed.
-
-### Adding a new link
+## Adding a new link
 
 - **Make an individual pull request for each link suggestion.**
-- Search previous suggestions before making a new one, as yours may be a duplicate.
-- Use the following format: `- [project-name](http://example.com/) - A short description ends with a period.`
-  - Keep the description short and simple, but descriptive.
-  - A description ends with a full stop/period `.`!
-  - Don't mention `Home Assistant` in the description as it's implied.
-- Check your spelling and grammar.
-- Make sure that your suggestion is positioned as the last item category.
+- Search previous suggestions before making a new one — yours may be a duplicate.
+- Use the following format:
 
-### Adding a new section/category
+  ```text
+  - [project-name](https://example.com/) - A short description ends with a period.
+  ```
+
+  - Keep the description short and simple, but descriptive.
+  - A description ends with a full stop / period `.`.
+  - The description **must not** start with the item name (e.g. "Foo" → "A useful tool…", not "Foo is a useful tool…").
+  - Don't mention "Home Assistant" in the description — it's implied.
+- Check your spelling and grammar.
+- Position your suggestion as the **last item** in the relevant category.
+
+## Adding a new section / category
 
 New categories or improvements to the existing categorization are welcome.
 
 - Ensure the section has a nice description.
-- A description ends with a full stop/period `.`!
+- A description ends with a full stop / period `.`.
 - Add the section to the table of contents.
 - Check your spelling and grammar.
 - Remove any trailing whitespace.
 
-### Deleting a link
+## Deleting a link
 
 Typical reasons for deleting links:
 
-- The item does no longer apply to or work with the latest Home Assistant.
-- No updates / abandoned.
+- The item no longer applies to or works with current Home Assistant.
+- No updates / abandoned upstream (fails the activity-window checks).
 - Deprecated.
-- In case of software: License missing.
+- License missing or no longer open source.
 - Dead link.
+- Project taken over and now distributing malware or content unrelated to its
+  original purpose. See [SECURITY.md](./SECURITY.md).


### PR DESCRIPTION
First half of the listing-validation effort: write the rules down before automating them. The CI that enforces these comes in a follow-up PR.

## What changed

Replaces the ~10-line "Link requirements" section with a proper acceptance-criteria spec, organized by what kind of entry the rule applies to.

### Universal — every entry
- HTTPS-only (no plain `http://`)
- No URL shorteners (`bit.ly`, `t.co`, `goo.gl`, `tinyurl.com`, etc.)
- No duplicate URLs across the README
- Tracking params (`utm_*`, `fbclid`, `gclid`) stripped (warning)

### Software entries (GitHub repos)
Applies to Apps, Custom Integrations, Custom Cards, Themes, Alternative Dashboards, DIY-linking-to-a-repo, and Alternative Home Automation Software.

- Not archived
- Pushed within last **18 months**
- At least **6 months old**
- Has `README.md` at root
- OSI-approved open-source license (no proprietary, no source-available like BSL/SSPL/Elastic-2.0)
- README mentions "Home Assistant" (warning, not blocker — for libs that are HA-adjacent)
- <10 stars → warning (PR author should explain why)

### HACS-installable
Custom Integrations and Custom Cards must have a valid `hacs.json`.

### Content (blogs, podcasts, YouTube)
- Last post / episode / upload within **12 months**

### Section exemptions
- **Public Configurations** — license check waived
- **DIY** linking to forum/blog (not a repo) — universal checks only
- **Other Awesome Lists** — accepts CC-BY / CC0 / CC-BY-SA in addition to OSI

### Subjective (manual review)
- Widely recommended, well-known, English
- Self-promotion check (PR author = repo owner) — flagged not blocked

## Tradeoffs we made

- **6 months minimum age** rather than 12 — HA's release cadence means projects can prove themselves over 4-6 core releases in 6 months.
- **18 months activity** for software rather than 12 — protects stable utility libraries that are "done" but still working.
- **Soft star warning rather than hard gate** — stars are gameable and penalize niche tools (specific car APIs, country-specific energy meters).
- **HA-mention as warning rather than block** — accommodates underlying libraries used by integrations.

## What's not here

- Description-quality heuristics ("the best", "amazing") — too many false positives
- Has-tests / has-CI checks — too aggressive for single-file tools
- Issue ratio / activity stats — too noisy
- Original-content checks for blogs/YouTube — can't automate cleanly