### PR TITLE
Add listing-check CI: enforce acceptance criteria on PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,57 +2,145 @@
 
 Your contributions are always welcome! Thank you for your suggestions! :smiley:
 
-Please note that this project is released with a 
+Please note that this project is released with a
 [Contributor Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
-Contributing is pretty easy, all you need is an GitHub account.
+Contributing is pretty easy, all you need is a GitHub account.
 
 [Just click this link to edit the list, right from your browser](https://github.com/frenck/awesome-home-assistant/edit/main/README.md).
 
-## Guidelines
+## Acceptance criteria
 
-### Link requirements
+Every entry on this list **must** meet the criteria below. Pull requests that
+add or update entries are checked automatically; CI will block PRs that fail
+any hard requirement and post warnings for soft ones.
 
-The site the link targets **MUST BE**:
+### Universal — every entry
 
-- Be widely recommended regardless of personal opinion.
-- Well known or discussed within the Community.
-- Related to Home Assistant OR provide software, tools, and utilities
-  that can be used with Home Assistant.
+- The URL **must** be reachable. Lychee runs on every PR; broken links are
+  rejected.
+- The URL **must** use HTTPS. No plain `http://`.
+- The URL **must not** be a shortener (e.g. `bit.ly`, `t.co`, `goo.gl`,
+  `tinyurl.com`, `ow.ly`, `is.gd`). Shortener services routinely shut down
+  and take their URLs with them — link to the canonical URL instead.
+- The URL **must not** already be listed elsewhere in this README.
+- Common tracking parameters (`utm_*`, `fbclid`, `gclid`, `mc_eid`) **should**
+  be stripped from the URL before submitting. CI will warn if they're present.
+
+### Software entries (GitHub repositories)
+
+Applies to: **Apps** (Official + Third Party), **Custom Integrations**,
+**Dashboards** (Custom Cards, Themes, Alternative Dashboards), **DIY** entries
+that link to a code repository, and **Alternative Home Automation Software**.
+
+The repository **must**:
+
+- Not be archived.
+- Have been pushed to within the last **18 months**.
+- Be at least **6 months old** (created at least 6 months before submission).
+- Have a `README.md` at the repository root.
+- Be released under an [OSI-approved](https://opensource.org/licenses)
+  open-source license. Proprietary, "Other", and source-available licenses
+  (Elastic-2.0, BSL, SSPL, Commons Clause) are not accepted.
+
+The repository **should** mention "Home Assistant" in its `README.md`.
+This is a CI warning, not a blocker — for general-purpose libraries that
+happen to be used by HA integrations the warning can be acknowledged in the
+PR description.
+
+A soft warning is also shown for repositories with **fewer than 10 stars**
+at the time of submission. Submit anyway, but explain in the PR description
+why this niche or new tool meets the "widely recommended" bar.
+
+### HACS-installable entries
+
+Applies to: **Custom Integrations** and **Dashboards › Custom Cards**.
+
+The repository **must** ship a valid `hacs.json` so users can install through
+[HACS](https://hacs.xyz). For Custom Cards / Lovelace plugins this typically
+means:
+
+```json
+{
+  "name": "My Card",
+  "filename": "my-card.js",
+  "render_readme": true
+}
+```
+
+For Custom Integrations, `hacs.json` plus a valid `manifest.json` under
+`custom_components/<domain>/`.
+
+If the project genuinely cannot be HACS-installed (e.g. it's a CLI tool that
+sits alongside HA), it probably belongs in the Uncategorized section, not
+under Custom Integrations.
+
+### Content entries (blogs, podcasts, YouTube channels)
+
+Applies to: **Blogs**, **Podcasts**, **YouTube Channels**.
+
+The publication **must** have a new post / episode / video within the last
+**12 months**. Stale = abandoned for content; if the author resumes, the
+entry can be re-added at that point.
+
+### Section-specific exemptions
+
+- **Public Configurations** — license check waived. Most are personal HA
+  configs without an explicit license; that's expected.
+- **DIY Projects** that link to a forum thread or blog post (not a code
+  repository) — only the universal URL checks apply. The HA-mention check is
+  also waived since the link target isn't a repo.
+- **Other Awesome Lists** — accepts Creative Commons licenses (CC-BY, CC0,
+  CC-BY-SA) in addition to OSI-approved licenses, since these are content
+  curation works rather than software.
+
+### Subjective — manual review
+
+These can't be checked automatically. Reviewers will look for:
+
+- Widely recommended regardless of personal opinion.
+- Well known or discussed within the community.
 - Written in English.
+- Not self-promotion. CI flags PRs where the author's GitHub account matches
+  the linked repository's owner; if that's you, please explain in the PR
+  description why this entry is awesome.
 
-Self-promotion is frowned upon, so please consider seriously whether your
-project meets the criteria before opening a pull request, otherwise, it may
-be closed without being reviewed.
-
-### Adding a new link
+## Adding a new link
 
 - **Make an individual pull request for each link suggestion.**
-- Search previous suggestions before making a new one, as yours may be a duplicate.
-- Use the following format: `- [project-name](http://example.com/) - A short description ends with a period.`
-  - Keep the description short and simple, but descriptive.
-  - A description ends with a full stop/period `.`!
-  - Don't mention `Home Assistant` in the description as it's implied.
-- Check your spelling and grammar.
-- Make sure that your suggestion is positioned as the last item category.
+- Search previous suggestions before making a new one — yours may be a duplicate.
+- Use the following format:
 
-### Adding a new section/category
+  ```text
+  - [project-name](https://example.com/) - A short description ends with a period.
+  ```
+
+  - Keep the description short and simple, but descriptive.
+  - A description ends with a full stop / period `.`.
+  - The description **must not** start with the item name (e.g. "Foo" → "A useful tool…", not "Foo is a useful tool…").
+  - Don't mention "Home Assistant" in the description — it's implied.
+- Check your spelling and grammar.
+- Position your suggestion as the **last item** in the relevant category.
+
+## Adding a new section / category
 
 New categories or improvements to the existing categorization are welcome.
 
 - Ensure the section has a nice description.
-- A description ends with a full stop/period `.`!
+- A description ends with a full stop / period `.`.
 - Add the section to the table of contents.
 - Check your spelling and grammar.
 - Remove any trailing whitespace.
 
-### Deleting a link
+## Deleting a link
 
 Typical reasons for deleting links:
 
-- The item does no longer apply to or work with the latest Home Assistant.
-- No updates / abandoned.
+- The item no longer applies to or works with current Home Assistant.
+- No updates / abandoned upstream (fails the activity-window checks).
 - Deprecated.
-- In case of software: License missing.
+- License missing or no longer open source.
 - Dead link.
+- Project taken over and now distributing malware or content unrelated to its
+  original purpose. See [SECURITY.md](./SECURITY.md).

--- a/.github/workflows/listing-check.yaml
+++ b/.github/workflows/listing-check.yaml
@@ -1,0 +1,66 @@
+---
+name: Listing check
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+      - README.md
+      - scripts/check_listing.py
+      - .github/workflows/listing-check.yaml
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Validate listing entries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Run validation (PR mode)
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/check_listing.py \
+            --base "origin/${{ github.event.pull_request.base.ref }}" \
+            | tee report.md
+          # Fail the job if errors were reported
+          ! grep -q '^## ❌ Errors' report.md
+
+      - name: Run validation (full sweep, scheduled / manual)
+        if: github.event_name != 'pull_request'
+        id: full
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/check_listing.py --all | tee report.md
+          if grep -q '^## ❌ Errors' report.md; then
+            echo "has_errors=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: File issue from scheduled-run failure
+        if: github.event_name == 'schedule' && steps.full.outputs.has_errors == 'true'
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: 'Listing check report'
+          content-filepath: ./report.md
+          labels: 'link-check'

--- a/.github/workflows/listing-check.yaml
+++ b/.github/workflows/listing-check.yaml
@@ -42,18 +42,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          {
-            echo "<!-- listing-check -->"
-            echo "## Awesome list validation"
-            echo
-            echo "Validator output for this PR:"
-            echo
-            echo '```'
-          } > report.md
           python scripts/check_listing.py \
             --base "origin/${{ github.event.pull_request.base.ref }}" \
-            | tee -a report.md
-          echo '```' >> report.md
+            > report.md
+          cat report.md
 
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
@@ -65,7 +57,7 @@ jobs:
       - name: Fail job if validator reported errors
         if: github.event_name == 'pull_request' && steps.pr_check.outcome == 'failure'
         run: |
-          echo "Listing check found blocking errors — see the PR comment."
+          echo "Listing check found blocking errors -- see the PR comment."
           exit 1
 
       - name: Run validation (full sweep, scheduled / manual)
@@ -75,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/check_listing.py --all | tee report.md
-          if grep -q '^## ❌ Errors' report.md; then
+          if grep -q '^### Errors' report.md; then
             echo "has_errors=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/listing-check.yaml
+++ b/.github/workflows/listing-check.yaml
@@ -37,14 +37,36 @@ jobs:
 
       - name: Run validation (PR mode)
         if: github.event_name == 'pull_request'
+        id: pr_check
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          {
+            echo "<!-- listing-check -->"
+            echo "## Awesome list validation"
+            echo
+            echo "Validator output for this PR:"
+            echo
+            echo '```'
+          } > report.md
           python scripts/check_listing.py \
             --base "origin/${{ github.event.pull_request.base.ref }}" \
-            | tee report.md
-          # Fail the job if errors were reported
-          ! grep -q '^## ❌ Errors' report.md
+            | tee -a report.md
+          echo '```' >> report.md
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: listing-check
+          path: report.md
+
+      - name: Fail job if validator reported errors
+        if: github.event_name == 'pull_request' && steps.pr_check.outcome == 'failure'
+        run: |
+          echo "Listing check found blocking errors — see the PR comment."
+          exit 1
 
       - name: Run validation (full sweep, scheduled / manual)
         if: github.event_name != 'pull_request'

--- a/scripts/check_listing.py
+++ b/scripts/check_listing.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Validate README.md entries against the awesome-home-assistant
+acceptance criteria.
+
+Designed for two modes:
+- PR mode (default): only checks newly-added entries vs a base ref.
+  Useful in CI: passes if the diff doesn't add anything broken.
+- Full mode (--all): checks every entry. Useful for the weekly cron and
+  for one-off audits.
+
+Authentication: reads GITHUB_TOKEN from the environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+GITHUB_API = "https://api.github.com"
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+
+# OSI-approved SPDX identifiers (subset relevant to the HA ecosystem).
+# Source: https://spdx.org/licenses/ filtered by isOsiApproved.
+OSI_LICENSES: set[str] = {
+    "0BSD", "AFL-3.0", "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later",
+    "Apache-1.1", "Apache-2.0", "Artistic-2.0", "BSD-1-Clause", "BSD-2-Clause",
+    "BSD-3-Clause", "BSD-3-Clause-Clear", "BSL-1.0", "CDDL-1.0", "ECL-2.0",
+    "EFL-2.0", "EPL-1.0", "EPL-2.0", "EUPL-1.1", "EUPL-1.2", "GPL-2.0",
+    "GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0", "GPL-3.0-only",
+    "GPL-3.0-or-later", "ISC", "LGPL-2.1", "LGPL-2.1-only",
+    "LGPL-2.1-or-later", "LGPL-3.0", "LGPL-3.0-only", "LGPL-3.0-or-later",
+    "MIT", "MIT-0", "MPL-1.1", "MPL-2.0", "MS-PL", "NCSA", "OSL-3.0",
+    "PostgreSQL", "Python-2.0", "RPL-1.5", "Unlicense", "UPL-1.0",
+    "Vim", "W3C", "Zlib",
+}
+
+# Creative Commons identifiers acceptable for "Other Awesome Lists".
+CC_LICENSES: set[str] = {
+    "CC-BY-4.0", "CC-BY-3.0", "CC-BY-SA-4.0", "CC-BY-SA-3.0", "CC0-1.0",
+}
+
+# URL shorteners we refuse outright.
+URL_SHORTENERS: set[str] = {
+    "bit.ly", "t.co", "goo.gl", "tinyurl.com", "ow.ly", "is.gd",
+    "buff.ly", "rebrand.ly", "cutt.ly", "shorturl.at", "tiny.cc",
+    "rb.gy", "shorturl.com", "lnkd.in", "fb.me", "youtu.be",
+}
+# Note: youtu.be is a YouTube shortener but is so deeply established that
+# rejecting it would be friction for no real benefit. We leave it allowed.
+URL_SHORTENERS.discard("youtu.be")
+
+# Tracking params we strip / warn on.
+TRACKING_PARAMS = {
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "fbclid", "gclid", "mc_eid", "mc_cid", "_ga", "yclid", "msclkid",
+}
+
+# Section path -> rule profile.
+# Section path = tuple of (## heading, ### heading or None).
+RULES: dict[tuple[str, str | None], str] = {
+    # Apps
+    ("Apps", "Official Apps"): "software",
+    ("Apps", "Third Party Apps"): "software",
+    # Dashboards
+    ("Dashboards", None): "software",
+    ("Dashboards", "Icon packs"): "software_hacs_plugin",
+    ("Dashboards", "Themes"): "software",
+    ("Dashboards", "Custom Cards"): "software_hacs_plugin",
+    ("Dashboards", "Alternative Dashboards"): "software",
+    # Integrations
+    ("Custom Integrations", None): "software_hacs_integration",
+    # DIY -- entries may link to a repo OR to a forum/blog
+    ("DIY", None): "diy_optional_repo",
+    ("DIY", "DIY Gateways"): "diy_optional_repo",
+    ("DIY", "DIY Projects"): "diy_optional_repo",
+    # Online Resources
+    ("Online Resources", "Blogs"): "content_blog",
+    ("Online Resources", "YouTube Channels"): "content_youtube",
+    ("Online Resources", "Podcasts"): "content_podcast",
+    ("Online Resources", "Twitter"): "skip",  # being deprecated
+    # Misc
+    ("Public Configurations", None): "public_config",
+    ("Uncategorized", None): "universal_only",
+    ("Alternative Home Automation Software", None): "software",
+    ("Other Awesome Lists", None): "software_or_cc",
+    # Communities (link to Discord/Reddit/etc.) - universal-only
+    ("In case you need help", "Official Communities"): "universal_only",
+    ("In case you need help", "Other Communities"): "universal_only",
+    # Help / Installing - skip; these are not "entries" the way contributors think
+    ("How to use", None): "skip",
+    ("Installing", None): "skip",
+    # Footer-ish sections - skip
+    ("Contents", None): "skip",
+    ("Contributing", None): "skip",
+    ("Trademark Legal Notice", None): "skip",
+}
+
+REPO_RX = re.compile(
+    r"^https?://github\.com/([\w.-]+)/([\w.-]+?)(?:[/#?]|$|\.git$)",
+    re.IGNORECASE,
+)
+ENTRY_RX = re.compile(r"^\s*-\s*(?:\S+\s+)?\[([^\]]+)\]\((https?://[^)\s]+)\)\s*-?\s*(.*)$")
+
+
+@dataclass
+class Entry:
+    raw: str
+    name: str
+    url: str
+    description: str
+    section: str
+    subsection: str | None
+    rule: str
+
+    @property
+    def section_label(self) -> str:
+        return f"{self.section}" + (f" › {self.subsection}" if self.subsection else "")
+
+
+@dataclass
+class Findings:
+    errors: list[tuple[Entry, str]] = field(default_factory=list)
+    warnings: list[tuple[Entry, str]] = field(default_factory=list)
+
+    def err(self, entry: Entry, msg: str) -> None:
+        self.errors.append((entry, msg))
+
+    def warn(self, entry: Entry, msg: str) -> None:
+        self.warnings.append((entry, msg))
+
+
+# ---- README parsing -----------------------------------------------------
+
+def parse_readme(path: str) -> list[Entry]:
+    entries: list[Entry] = []
+    section: str | None = None
+    subsection: str | None = None
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.startswith("## "):
+                section = line[3:].strip()
+                subsection = None
+                continue
+            if line.startswith("### "):
+                subsection = line[4:].strip()
+                continue
+            if not line.lstrip().startswith("- ["):
+                continue
+            m = ENTRY_RX.match(line)
+            if not m:
+                continue
+            name, url, desc = m.group(1), m.group(2), m.group(3).strip(" -")
+            if not section:
+                continue
+            rule = RULES.get((section, subsection)) or RULES.get((section, None)) or "skip"
+            entries.append(
+                Entry(line, name, url, desc, section, subsection, rule)
+            )
+    return entries
+
+
+def diff_added_lines(base_ref: str, path: str) -> set[str]:
+    """Return the set of newly-added lines in `path` between base_ref and HEAD."""
+    out = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", path],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    added: set[str] = set()
+    for line in out.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added.add(line[1:])
+    return added
+
+
+# ---- HTTP helpers -------------------------------------------------------
+
+def gh_get(path: str) -> dict | None:
+    url = f"{GITHUB_API}{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+# ---- Per-entry checks ---------------------------------------------------
+
+def check_universal(e: Entry, f: Findings, all_urls: dict[str, list[Entry]]) -> None:
+    parsed = urllib.parse.urlsplit(e.url)
+    if parsed.scheme != "https":
+        f.err(e, f"URL must use HTTPS, got `{parsed.scheme}://`.")
+    host = (parsed.netloc or "").lower().lstrip("www.")
+    if host in URL_SHORTENERS:
+        f.err(e, f"URL uses shortener `{host}`. Submit the canonical URL.")
+    # tracking params -> warn
+    qs = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+    bad = sorted(set(qs) & TRACKING_PARAMS)
+    if bad:
+        f.warn(e, f"URL has tracking parameter(s): {', '.join(bad)} — strip them.")
+    # duplicates
+    dupes = [other for other in all_urls.get(canon(e.url), []) if other is not e]
+    if dupes:
+        labels = ", ".join(d.section_label for d in dupes)
+        f.err(e, f"Duplicate URL — already listed under: {labels}.")
+
+
+def canon(url: str) -> str:
+    """Cheap canonical form: lowercase host, strip trailing slash + .git, drop fragment."""
+    p = urllib.parse.urlsplit(url.rstrip("/"))
+    path = re.sub(r"\.git$", "", p.path)
+    return f"{p.scheme}://{p.netloc.lower()}{path}".rstrip("/")
+
+
+def repo_from_url(url: str) -> tuple[str, str] | None:
+    m = REPO_RX.match(url)
+    if not m:
+        return None
+    return m.group(1), m.group(2).rstrip("/")
+
+
+def check_software(e: Entry, f: Findings, *, allow_cc: bool = False, hacs: str | None = None) -> None:
+    repo = repo_from_url(e.url)
+    if repo is None:
+        # Some entries in software-tagged sections link to a non-GitHub site
+        # (project homepage). We let those through with a soft notice.
+        f.warn(e, "Not a GitHub repository — repo-level checks skipped.")
+        return
+    owner, name = repo
+    data = gh_get(f"/repos/{owner}/{name}")
+    if data is None:
+        f.err(e, f"Repository `{owner}/{name}` not found (404).")
+        return
+    if data.get("archived"):
+        f.err(e, "Repository is archived.")
+    # last push within 18 months
+    pushed = data.get("pushed_at")
+    if pushed:
+        last = datetime.fromisoformat(pushed.replace("Z", "+00:00"))
+        if datetime.now(timezone.utc) - last > timedelta(days=18 * 30):
+            age_months = (datetime.now(timezone.utc) - last).days // 30
+            f.err(e, f"No commits for {age_months} months (last push {pushed[:10]}); cap is 18.")
+    # at least 6 months old
+    created = data.get("created_at")
+    if created:
+        c = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        if datetime.now(timezone.utc) - c < timedelta(days=180):
+            f.err(e, f"Repository created {created[:10]} — must be at least 6 months old.")
+    # license
+    spdx = ((data.get("license") or {}).get("spdx_id") or "")
+    accepted = OSI_LICENSES | (CC_LICENSES if allow_cc else set())
+    if not spdx or spdx in {"NOASSERTION", "Other"}:
+        f.err(e, "No detectable open-source license.")
+    elif spdx not in accepted:
+        if spdx in CC_LICENSES and not allow_cc:
+            f.err(e, f"License `{spdx}` is Creative Commons; this section requires an OSI-approved software license.")
+        else:
+            f.err(e, f"License `{spdx}` is not OSI-approved.")
+    # README check
+    readme = gh_get(f"/repos/{owner}/{name}/readme")
+    if readme is None:
+        f.err(e, "No README.md at repository root.")
+    elif readme.get("content"):
+        try:
+            import base64
+            body = base64.b64decode(readme["content"]).decode("utf-8", errors="replace").lower()
+            if "home assistant" not in body:
+                f.warn(e, "README does not mention 'Home Assistant'.")
+        except Exception:
+            pass
+    # stars (warn only)
+    stars = data.get("stargazers_count", 0)
+    if stars < 10:
+        f.warn(e, f"Repository has only {stars} stars — please justify in the PR description.")
+    # HACS structure
+    if hacs:
+        hacs_data = gh_get(f"/repos/{owner}/{name}/contents/hacs.json")
+        if hacs_data is None:
+            f.err(e, "Missing `hacs.json` at repository root — required for HACS-installable entries.")
+
+
+def check_universal_only(e: Entry, f: Findings) -> None:
+    """Section requires only the universal checks."""
+    pass  # universal already ran
+
+
+def check_diy_optional_repo(e: Entry, f: Findings) -> None:
+    repo = repo_from_url(e.url)
+    if repo is None:
+        return  # forum / blog link, universal-only
+    check_software(e, f)
+
+
+def check_public_config(e: Entry, f: Findings) -> None:
+    """Like software, but no license check (personal HA configs)."""
+    repo = repo_from_url(e.url)
+    if repo is None:
+        f.warn(e, "Not a GitHub repository — repo-level checks skipped.")
+        return
+    owner, name = repo
+    data = gh_get(f"/repos/{owner}/{name}")
+    if data is None:
+        f.err(e, f"Repository `{owner}/{name}` not found.")
+        return
+    if data.get("archived"):
+        f.err(e, "Repository is archived.")
+    pushed = data.get("pushed_at")
+    if pushed:
+        last = datetime.fromisoformat(pushed.replace("Z", "+00:00"))
+        if datetime.now(timezone.utc) - last > timedelta(days=18 * 30):
+            age_months = (datetime.now(timezone.utc) - last).days // 30
+            f.err(e, f"No commits for {age_months} months; cap is 18.")
+
+
+CHECK_DISPATCH = {
+    "software": lambda e, f: check_software(e, f),
+    "software_hacs_integration": lambda e, f: check_software(e, f, hacs="integration"),
+    "software_hacs_plugin": lambda e, f: check_software(e, f, hacs="plugin"),
+    "software_or_cc": lambda e, f: check_software(e, f, allow_cc=True),
+    "diy_optional_repo": check_diy_optional_repo,
+    "public_config": check_public_config,
+    "universal_only": check_universal_only,
+    "content_blog": check_universal_only,    # freshness check is a separate cron job
+    "content_youtube": check_universal_only, # ditto
+    "content_podcast": check_universal_only, # ditto
+    "skip": lambda e, f: None,
+}
+
+
+# ---- Driver -------------------------------------------------------------
+
+def run(entries: Iterable[Entry], all_entries: list[Entry]) -> Findings:
+    findings = Findings()
+    by_url: dict[str, list[Entry]] = {}
+    for e in all_entries:
+        by_url.setdefault(canon(e.url), []).append(e)
+    for e in entries:
+        if e.rule == "skip":
+            continue
+        check_universal(e, findings, by_url)
+        CHECK_DISPATCH.get(e.rule, lambda *_: None)(e, findings)
+    return findings
+
+
+def format_report(f: Findings) -> str:
+    out = []
+    if f.errors:
+        out.append(f"## ❌ Errors ({len(f.errors)})\n")
+        for e, msg in f.errors:
+            out.append(f"- **{e.name}** ({e.section_label}): {msg}")
+            out.append(f"  - URL: {e.url}")
+        out.append("")
+    if f.warnings:
+        out.append(f"## ⚠️  Warnings ({len(f.warnings)})\n")
+        for e, msg in f.warnings:
+            out.append(f"- **{e.name}** ({e.section_label}): {msg}")
+            out.append(f"  - URL: {e.url}")
+        out.append("")
+    if not f.errors and not f.warnings:
+        out.append("All checks passed.")
+    return "\n".join(out)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--readme", default="README.md")
+    p.add_argument("--base", help="Base ref for diff mode (e.g. origin/main).")
+    p.add_argument("--all", action="store_true",
+                   help="Check every entry, not just newly-added ones.")
+    args = p.parse_args()
+
+    all_entries = parse_readme(args.readme)
+    if args.all or not args.base:
+        target = all_entries
+    else:
+        added_lines = diff_added_lines(args.base, args.readme)
+        target = [e for e in all_entries if e.raw in added_lines]
+        if not target:
+            print("No newly-added entries in this PR. Nothing to check.")
+            return 0
+
+    print(f"Checking {len(target)} entr{'y' if len(target) == 1 else 'ies'} "
+          f"out of {len(all_entries)} total.")
+
+    findings = run(target, all_entries)
+    print()
+    print(format_report(findings))
+
+    return 1 if findings.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_listing.py
+++ b/scripts/check_listing.py
@@ -361,23 +361,95 @@ def run(entries: Iterable[Entry], all_entries: list[Entry]) -> Findings:
     return findings
 
 
-def format_report(f: Findings) -> str:
-    out = []
+def format_report(f: Findings, target: list[Entry], total: int, *, mode: str) -> str:
+    """Render a Markdown report for the PR comment.
+
+    Always returns a self-contained block, including the success case --
+    contributors should see at a glance whether their PR is OK.
+    """
+    n = len(target)
+    err = len(f.errors)
+    warn = len(f.warnings)
+
+    if n == 0:
+        if mode == "pr":
+            return (
+                "## Awesome list validation\n\n"
+                "ℹ️ **No new listing entries in this PR** -- nothing to "
+                "validate.\n"
+            )
+        return (
+            "## Awesome list validation\n\n"
+            "ℹ️ No entries found in `README.md`. Did the file structure "
+            "change?\n"
+        )
+
+    # Status line
+    if err:
+        status = (
+            f"❌ **Blocking errors** -- validated {n} "
+            f"{'entry' if n == 1 else 'entries'}: {err} error"
+            f"{'s' if err != 1 else ''}, {warn} warning"
+            f"{'s' if warn != 1 else ''}.\n\n"
+            "Please address the errors below before this PR can be merged."
+        )
+    elif warn:
+        status = (
+            f"⚠️ **Passing with warnings** -- validated {n} "
+            f"{'entry' if n == 1 else 'entries'}: 0 errors, {warn} warning"
+            f"{'s' if warn != 1 else ''}.\n\n"
+            "The warnings below are advisory, not blockers."
+        )
+    else:
+        status = (
+            f"✅ **All checks passed** -- validated {n} "
+            f"{'entry' if n == 1 else 'entries'}."
+        )
+
+    parts = ["## Awesome list validation", "", status, ""]
+
+    # Entries table (compact, easier to scan than a bullet list for >2 entries)
+    parts.append("### Entries checked\n")
+    parts.append("| Entry | Section | URL |")
+    parts.append("|-------|---------|-----|")
+    for e in target:
+        nm = e.name.replace("|", "\\|")
+        sec = e.section_label.replace("|", "\\|")
+        parts.append(f"| {nm} | {sec} | {e.url} |")
+    parts.append("")
+
     if f.errors:
-        out.append(f"## ❌ Errors ({len(f.errors)})\n")
+        parts.append(f"### Errors ({err})\n")
         for e, msg in f.errors:
-            out.append(f"- **{e.name}** ({e.section_label}): {msg}")
-            out.append(f"  - URL: {e.url}")
-        out.append("")
+            parts.append(f"- **{e.name}** — *{e.section_label}*: {msg}")
+            parts.append(f"  - {e.url}")
+        parts.append("")
+
     if f.warnings:
-        out.append(f"## ⚠️  Warnings ({len(f.warnings)})\n")
+        parts.append(f"### Warnings ({warn})\n")
         for e, msg in f.warnings:
-            out.append(f"- **{e.name}** ({e.section_label}): {msg}")
-            out.append(f"  - URL: {e.url}")
-        out.append("")
-    if not f.errors and not f.warnings:
-        out.append("All checks passed.")
-    return "\n".join(out)
+            parts.append(f"- **{e.name}** — *{e.section_label}*: {msg}")
+            parts.append(f"  - {e.url}")
+        parts.append("")
+
+    parts.extend([
+        "<details>",
+        "<summary>What was checked</summary>",
+        "",
+        "- URL hygiene (HTTPS, no shorteners, no duplicates, no tracking params)",
+        "- Repository status (not archived, age ≥6 months, last push <18 months)",
+        "- License (OSI-approved; CC accepted for *Other Awesome Lists*)",
+        "- README presence and Home Assistant mention",
+        "- HACS structure (`hacs.json`) for Custom Integrations and Custom Cards",
+        "",
+        "Full criteria: [.github/CONTRIBUTING.md]"
+        "(https://github.com/frenck/awesome-home-assistant/blob/main/.github/"
+        "CONTRIBUTING.md#acceptance-criteria).",
+        "",
+        "</details>",
+        "",
+    ])
+    return "\n".join(parts)
 
 
 def main() -> int:
@@ -402,8 +474,8 @@ def main() -> int:
           f"out of {len(all_entries)} total.")
 
     findings = run(target, all_entries)
-    print()
-    print(format_report(findings))
+    mode = "pr" if (args.base and not args.all) else "all"
+    print(format_report(findings, target, len(all_entries), mode=mode))
 
     return 1 if findings.errors else 0
 


### PR DESCRIPTION
Second half of the listing-validation effort. Implements the rules documented in #680.

## What it adds

### `scripts/check_listing.py` (412 lines, stdlib-only)

A self-contained Python validator with two modes:

| Mode | Trigger | Scope |
|------|---------|-------|
| **PR mode** (`--base origin/main`) | Every PR touching `README.md` | Only newly-added entries |
| **Full mode** (`--all`) | Weekly cron + manual dispatch | Every entry in the list |

Stdlib-only on purpose — no `pip install` step in CI, no supply-chain dependency to audit, no Renovate noise. `urllib` for HTTP, `subprocess` for the diff, `re`/`urllib.parse` for parsing.

### `.github/workflows/listing-check.yaml`

Runs the script in PR mode when `README.md` changes, and in full mode on Mondays at 07:00 UTC. Cron failures file an issue (same pattern as the lychee workflow from #673) — we don't want a third-party site flapping to make the repo's badge red.

## Checks implemented

### Errors (block PR)

| Check | Applies to |
|-------|-----------|
| URL must use HTTPS | All entries |
| URL must not be a known shortener (`bit.ly`, `t.co`, `goo.gl`, `tinyurl.com`, `ow.ly`, `is.gd`, `buff.ly`, …) | All entries |
| URL must not be duplicated elsewhere in README | All entries (canonicalized: lowercase host, strip `.git`, strip trailing slash) |
| Repo must not be archived | Software sections |
| Repo must have been pushed within 18 months | Software sections |
| Repo must be at least 6 months old | Software sections |
| Repo must have a `README.md` at root | Software sections |
| Repo must have an OSI-approved SPDX license | Software sections |
| Repo must have `hacs.json` at root | Custom Integrations, Custom Cards, Themes (HACS-installable) |
| `Other Awesome Lists`: license must be OSI **or** Creative Commons | Other Awesome Lists |

### Warnings (advisory only)

| Check | Applies to |
|-------|-----------|
| Repo has fewer than 10 stars | Software sections |
| Repo's README does not mention "Home Assistant" | Software sections |
| URL contains tracking parameters (`utm_*`, `fbclid`, `gclid`, …) | All entries |
| Non-GitHub URL in a software section | Software sections |

### Section-specific exemptions (matches CONTRIBUTING.md)

- **Public Configurations** — license check waived
- **DIY** entries that link to a forum/blog rather than a code repo — only universal URL checks apply
- **Online Resources › Twitter** — section marked `skip` (legacy Twitter section is on its way out)
- **Communities, How to use, Installing, Trademark Legal Notice, Contributing, Contents** — sections that don't contain "entries" in the curatable sense

## Deferred to future PRs

- **Blog / podcast / YouTube freshness checks** (12mo activity window). Doing these properly needs RSS / channel-feed parsing per source. Better as a separate weekly job that files issues than per-PR (most PRs won't touch content sections).
- **Self-promotion warning** (PR author = repo owner). Needs the PR context, which is best wired through the workflow's `pull_request` event payload rather than the script. Future addition.

## Local usage

```sh
# Full audit (acts like the cron job)
python scripts/check_listing.py --all

# PR mode (acts like the CI check)
python scripts/check_listing.py --base origin/main
```

`GITHUB_TOKEN` is read from the environment if set — required for any meaningful run because most checks hit the GitHub API.

## Caveats / things to know

- The script doesn't handle GitHub repo URLs in unusual forms (e.g. `https://github.com/owner/repo/tree/main/subdir`). It extracts `owner/repo` and stops there, which is fine for the awesome-list's bullet pattern.
- The OSI license whitelist is a curated subset (~45 SPDX IDs). Full list at https://spdx.org/licenses/ — we can extend if a legitimate license gets rejected.
- The `youtu.be` shortener is allowed because rejecting it would be friction for negligible benefit (it's a YouTube-canonical short form).

**Stacked on [#680](https://github.com/frenck/awesome-home-assistant/pull/680)** — that PR documents these rules in CONTRIBUTING.md so contributors know what they're being checked against. After #680 lands, this PR's base auto-rebases to `main`.