### PR TITLE
Add weekly maintenance workflow with HACS-aware activity check

### DIFF
--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -1,0 +1,69 @@
+---
+name: Weekly maintenance
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '0 6 * * 5'  # Fridays at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  maintenance:
+    name: Refresh stars and run activity check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Refresh inline star counts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/update_stars.py
+
+      - name: Run activity check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/check_activity.py > activity-report.md
+
+      - name: Validate updated README
+        run: npx awesome-lint@2.3.0
+
+      - name: Compose PR body
+        run: |
+          {
+            echo "Automated weekly maintenance run."
+            echo
+            echo "## Star counts"
+            echo
+            echo "Refreshed via \`scripts/update_stars.py\` (HACS data first, GitHub API fallback for repos HACS does not cover). See the README diff for the changes."
+            echo
+            cat activity-report.md
+            echo
+            echo "_Triggered by the Weekly maintenance workflow. Review the diff and the activity check above, drop entries you no longer want, then merge._"
+          } > pr-body.md
+
+      - name: Open or update maintenance PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/weekly-maintenance
+          base: main
+          delete-branch: true
+          add-paths: README.md
+          commit-message: 'chore: weekly star count refresh'
+          title: 'Weekly maintenance: refresh stars and flag inactive repos'
+          body-path: pr-body.md
+          labels: maintenance

--- a/scripts/_hacs.py
+++ b/scripts/_hacs.py
@@ -1,0 +1,58 @@
+"""Helpers for the HACS public data index.
+
+HACS publishes its default-store metadata as one plain JSON file per
+category. No auth, no rate limit. Each entry has a `full_name`, a
+`stargazers_count`, and a `last_updated` timestamp, which is exactly
+what `update_stars.py` and `check_activity.py` both need.
+
+Bonus: HACS removes archived projects from its public store, so any
+repo present in this index is implicitly known to be active and not
+archived. That lets the activity check skip the GitHub API for ~40% of
+the listing.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+HACS_DATA_BASE = "https://data-v2.hacs.xyz"
+HACS_CATEGORIES = (
+    "integration",
+    "plugin",
+    "theme",
+    "appdaemon",
+    "python_script",
+    "netdaemon",
+)
+
+
+def load_hacs_index() -> dict[tuple[str, str], dict]:
+    """Return a {(owner_lc, repo_lc): {stargazers_count, last_updated}} map.
+
+    One HTTPS request per category, no auth required. Entries missing a
+    `full_name` are skipped. Either field on the value dict may be None
+    when HACS does not have that value for an entry.
+    """
+    table: dict[tuple[str, str], dict] = {}
+    headers = {"User-Agent": "awesome-home-assistant-maintenance"}
+    for category in HACS_CATEGORIES:
+        url = f"{HACS_DATA_BASE}/{category}/data.json"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=20) as r:
+                data = json.loads(r.read())
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+            print(f"  ! HACS {category} unavailable: {e}", file=sys.stderr)
+            continue
+        for info in data.values():
+            full = (info.get("full_name") or "").lower()
+            if "/" not in full:
+                continue
+            owner, repo = full.split("/", 1)
+            table[(owner, repo)] = {
+                "stargazers_count": info.get("stargazers_count"),
+                "last_updated": info.get("last_updated"),
+            }
+    return table

--- a/scripts/check_activity.py
+++ b/scripts/check_activity.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Flag README entries pointing at archived, gone, or stale GitHub repos.
+
+Reports rather than edits. The weekly maintenance workflow includes the
+markdown report in the PR body so a human can decide whether to drop,
+replace, or keep the entry.
+
+Smart use of HACS: HACS removes archived integrations and plugins from
+its public store, so every repo present in HACS is implicitly active.
+We only hit the GitHub API for repos that are not in HACS (awesome-*
+lists, blogs, non-HACS-installable tooling), and for those we get
+archived status, 404, and `pushed_at` in a single response.
+
+A repo is flagged when:
+
+    * GitHub returns 404 (deleted, renamed without redirect, made private),
+    * the repo has been archived,
+    * it has not received an update in 730 days (~24 months).
+
+Output is markdown to stdout. Exit code is always 0 regardless of how
+many repos were flagged. This is informational, not a gate.
+
+Usage:
+
+    python scripts/check_activity.py             # markdown report to stdout
+    python scripts/check_activity.py --readme custom/path.md
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from _hacs import load_hacs_index
+
+GITHUB_API = "https://api.github.com"
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+STALE_DAYS = 730  # ~24 months
+
+REPO_RX = re.compile(
+    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[^/#?\s]+?)(?:\.git)?(?:/#.*|#.*|/)?$",
+    re.IGNORECASE,
+)
+ENTRY_RX = re.compile(
+    r"^\s*-\s*(?:\S+\s+)?\[(?P<name>[^\]]+)\]\((?P<url>https?://[^)\s]+)\)"
+)
+
+
+def fetch_repo(owner: str, repo: str) -> dict:
+    """GitHub /repos response, or {'_404': True} if the repo is gone."""
+    url = f"{GITHUB_API}/repos/{owner}/{repo}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return {"_404": True}
+        raise
+
+
+def parse_iso(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    p.add_argument("--readme", default="README.md")
+    args = p.parse_args()
+
+    text = open(args.readme).read()
+    by_repo: dict[tuple[str, str], list[tuple[int, str]]] = {}
+    for idx, line in enumerate(text.splitlines(), start=1):
+        m = ENTRY_RX.match(line)
+        if not m:
+            continue
+        rm = REPO_RX.match(m.group("url"))
+        if not rm:
+            continue
+        key = (rm.group("owner").lower(), rm.group("repo").lower())
+        by_repo.setdefault(key, []).append((idx, m.group("name")))
+
+    print(f"Activity check: {len(by_repo)} unique repos referenced.", file=sys.stderr)
+    print("Loading HACS index...", file=sys.stderr)
+    hacs = load_hacs_index()
+    print(f"  HACS index: {len(hacs)} repos.", file=sys.stderr)
+
+    now = dt.datetime.now(dt.timezone.utc)
+    cutoff = now - dt.timedelta(days=STALE_DAYS)
+
+    archived: list[tuple[str, list[tuple[int, str]]]] = []
+    missing: list[tuple[str, list[tuple[int, str]]]] = []
+    stale: list[tuple[str, int, list[tuple[int, str]]]] = []
+
+    api_pending: list[tuple[str, str]] = []
+    for key, occurrences in by_repo.items():
+        info = hacs.get(key)
+        if info is not None:
+            # HACS knows this repo, so it is active and not archived.
+            # Use HACS `last_updated` for the staleness check.
+            ts = parse_iso(info.get("last_updated"))
+            if ts and ts < cutoff:
+                stale.append((f"{key[0]}/{key[1]}", (now - ts).days, occurrences))
+        else:
+            api_pending.append(key)
+
+    print(
+        f"  {len(by_repo) - len(api_pending)} resolved via HACS, "
+        f"{len(api_pending)} need GitHub API.",
+        file=sys.stderr,
+    )
+
+    if api_pending:
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            futures = {ex.submit(fetch_repo, o, r): (o, r) for o, r in api_pending}
+            for fut in as_completed(futures):
+                key = futures[fut]
+                occurrences = by_repo[key]
+                full = f"{key[0]}/{key[1]}"
+                try:
+                    info = fut.result()
+                except Exception as e:
+                    print(f"  ! error fetching {full}: {e}", file=sys.stderr)
+                    continue
+                if info.get("_404"):
+                    missing.append((full, occurrences))
+                    continue
+                if info.get("archived"):
+                    archived.append((full, occurrences))
+                    continue
+                ts = parse_iso(info.get("pushed_at"))
+                if ts and ts < cutoff:
+                    stale.append((full, (now - ts).days, occurrences))
+
+    def fmt_cite(occurrences: list[tuple[int, str]]) -> str:
+        return ", ".join(f"L{ln} `{nm}`" for ln, nm in occurrences)
+
+    print("## Activity check")
+    print()
+    if not (missing or archived or stale):
+        print(
+            f"All entries pass the activity check (no archived, missing, or "
+            f"{STALE_DAYS}+ day stale repos)."
+        )
+        return 0
+
+    if missing:
+        print(f"### Missing or renamed ({len(missing)})")
+        print()
+        print(
+            "These URLs return 404. Likely candidates for removal or "
+            "replacement."
+        )
+        print()
+        for full, occ in sorted(missing):
+            print(f"- [{full}](https://github.com/{full}): {fmt_cite(occ)}")
+        print()
+
+    if archived:
+        print(f"### Archived ({len(archived)})")
+        print()
+        print(
+            "Owners have archived these repos. Not always a removal trigger. "
+            "Some projects archive after reaching feature complete but still "
+            "work fine. Review case by case."
+        )
+        print()
+        for full, occ in sorted(archived):
+            print(f"- [{full}](https://github.com/{full}): {fmt_cite(occ)}")
+        print()
+
+    if stale:
+        print(f"### Stale ({len(stale)})")
+        print()
+        print(
+            f"No update in {STALE_DAYS}+ days. Some smart-home tools simply "
+            "do not need updates; others are abandoned. Spot-check before "
+            "removing."
+        )
+        print()
+        for full, age, occ in sorted(stale, key=lambda x: -x[1]):
+            print(f"- [{full}](https://github.com/{full}): {age}d ago, {fmt_cite(occ)}")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_stars.py
+++ b/scripts/update_stars.py
@@ -33,21 +33,10 @@ import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from _hacs import load_hacs_index
+
 GITHUB_API = "https://api.github.com"
 TOKEN = os.environ.get("GITHUB_TOKEN", "")
-
-# HACS publishes its default-store metadata as plain JSON. One file per
-# category. No auth, no rate limit. Each entry has a `full_name` and a
-# `stargazers_count`, which is exactly what we want.
-HACS_DATA_BASE = "https://data-v2.hacs.xyz"
-HACS_CATEGORIES = (
-    "integration",
-    "plugin",
-    "theme",
-    "appdaemon",
-    "python_script",
-    "netdaemon",
-)
 
 # Match a GitHub repo URL pointing at the repo root. Trailing `.git` or
 # `#anchor` are accepted; subpaths like `/blob/...` or `/tree/...` are
@@ -90,38 +79,6 @@ def fetch_stars(owner: str, repo: str) -> int | None:
         raise
 
 
-def load_hacs_index() -> dict[tuple[str, str], int]:
-    """Pull the HACS public data files and build a (owner_lc, repo_lc) ->
-    stars lookup. One HTTPS request per category, no auth required.
-
-    HACS does not list every repo we curate (it does not include
-    awesome-* lists, blogs, or non-HACS-installable tooling), but it does
-    cover most custom integrations and Lovelace plugins, which is the bulk
-    of this list."""
-    table: dict[tuple[str, str], int] = {}
-    headers = {"User-Agent": "awesome-home-assistant-update-stars"}
-    for category in HACS_CATEGORIES:
-        url = f"{HACS_DATA_BASE}/{category}/data.json"
-        req = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=20) as r:
-                data = json.loads(r.read())
-        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
-            print(f"  ! HACS {category} unavailable: {e}", file=sys.stderr)
-            continue
-        for info in data.values():
-            full = (info.get("full_name") or "").lower()
-            if "/" not in full:
-                continue
-            owner, repo = full.split("/", 1)
-            stars = info.get("stargazers_count")
-            if stars is None:
-                continue
-            table[(owner, repo)] = stars
-    print(f"  HACS index loaded: {len(table)} repos.")
-    return table
-
-
 def update_text(text: str, dry_run: bool = False) -> tuple[str, int, int]:
     """Return (new_text, lines_updated, repos_seen)."""
     lines = text.splitlines()
@@ -144,12 +101,14 @@ def update_text(text: str, dry_run: bool = False) -> tuple[str, int, int]:
     # that HACS does not know about (awesome-* lists, blogs, tooling).
     print("  Loading HACS index...")
     hacs = load_hacs_index()
+    print(f"  HACS index: {len(hacs)} repos.")
 
     star_by_repo: dict[tuple[str, str], int | None] = {}
     api_pending: list[tuple[str, str]] = []
     for key in pending:
-        if key in hacs:
-            star_by_repo[key] = hacs[key]
+        info = hacs.get(key)
+        if info and info.get("stargazers_count") is not None:
+            star_by_repo[key] = info["stargazers_count"]
         else:
             api_pending.append(key)
     print(f"  {len(star_by_repo)} resolved via HACS, {len(api_pending)} need GitHub API.")


### PR DESCRIPTION
Automates the recurring upkeep this list needs so star counts stay current and dead entries surface on their own.

## What it does

Runs every Friday at 06:00 UTC, and is also available as a manual **Run workflow** button in the Actions tab (`workflow_dispatch`). On each run:

1. Refresh inline star counts via `scripts/update_stars.py`.
2. Scan all GitHub-linked entries via `scripts/check_activity.py` for repos that are archived, gone (404), or have not received an update in 730+ days (~24 months).
3. Validate the resulting README with `awesome-lint`.
4. Open or update a single PR (`chore/weekly-maintenance`) with the README diff and the activity report in the PR body.

A second weekly run does not create a new PR; it force-pushes onto the existing branch and updates the same PR. So you never see more than one open maintenance PR.

## Smart use of HACS

HACS publishes its store as plain JSON (`https://data-v2.hacs.xyz/<category>/data.json`, no auth, no rate limit). Each entry includes `stargazers_count` and `last_updated`. We exploit two properties:

- **HACS already covers ~40% of the listing**, so we read those star counts and last-update timestamps without a single GitHub API call.
- **HACS removes archived projects from its public store**, so any repo present in HACS is implicitly known to be active and not archived. Saves another API call we would otherwise make per repo.

The remaining ~60% (awesome-* lists, blogs, non-HACS-installable tooling) hit the GitHub API once per repo and pick up `archived`, `pushed_at`, and 404 status in a single response. Total: roughly 70 authenticated API calls per run, well within the Actions `GITHUB_TOKEN` 1000/hr budget.

## Files

- `scripts/_hacs.py`: shared HACS index loader returning `{stargazers_count, last_updated}` per repo. Used by both maintenance scripts.
- `scripts/update_stars.py`: refactored to import the shared loader. Behavior unchanged.
- `scripts/check_activity.py`: new. HACS-first staleness, archive, and 404 detection. Outputs markdown to stdout. Always exits 0; informational, not a gate.
- `.github/workflows/maintenance.yaml`: new. Friday cron + manual trigger. Pre-validates with awesome-lint before opening the PR, so the bot's PR is shippable when it appears.

## Sample activity report

A local run already surfaces useful signal from HACS data alone:

```
### Stale (9)

No update in 730+ days. Some smart-home tools simply do not need updates;
others are abandoned. Spot-check before removing.

- [custom-cards/bignumber-card](https://github.com/custom-cards/bignumber-card): 1557d ago, L258 `Big Number Card`
- [gurbyz/power-wheel-card](https://github.com/gurbyz/power-wheel-card): 1432d ago, L280 `Power Wheel Card`
- [benct/lovelace-xiaomi-vacuum-card](https://github.com/benct/lovelace-xiaomi-vacuum-card): 1206d ago, L294 `Xiaomi Vacuum Card`
... (6 more)
```

In CI with `GITHUB_TOKEN`, the report adds **Archived** and **Missing or renamed** sections for the non-HACS half of the listing.

## Operational notes

- Token: the workflow uses the default `GITHUB_TOKEN`. PRs opened by `GITHUB_TOKEN` do not trigger downstream workflows (GitHub anti-loop), so listing-check / lint / link-check will not auto-run on the bot PR. The maintenance workflow runs `awesome-lint` inline before opening the PR, so the result is pre-validated. If you ever want full CI on the bot PR, swap `secrets.GITHUB_TOKEN` for a PAT.
- Thresholds: stale window is 730 days. Tunable via the `STALE_DAYS` constant in `scripts/check_activity.py`.

## Verification

- Both Python scripts smoke-tested locally against the current README. HACS index loaded 3,017 entries, resolved 40/112 of our repos, surfaced 9 stale entries.
- No em or en dashes anywhere (lint/style preference).
- Workflow uses SHA-pinned actions matching the existing workflows.