### PR TITLE
Add Mushroom Strategy to Alternative Dashboards (closes #529)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ _Hide the chrome, run full-screen, or turn an old tablet on the wall into a dedi
 ### Alternative Dashboards
 
 - [Dwains Dashboard](https://github.com/dwainscheeren/dwains-lovelace-dashboard) - An fully auto-generating dashboard for desktop, tablet and mobile (2,033★).
+- [Mushroom Strategy](https://github.com/DigiLive/mushroom-strategy) - A strategy that automatically generates a dashboard using Mushroom cards (640★).
 
 ## Custom Integrations
 
@@ -548,6 +549,7 @@ _Like this list, but for adjacent topics? The lists below cover broader smart-ho
 - [awesome-iot](https://github.com/HQarroum/awesome-iot) - Curated list of awesome Internet of Things projects and resources (3,928★).
 - [awesome-mqtt](https://github.com/awesome-mqtt/awesome-mqtt#readme) - Curated list of MQTT related stuff (2,332★).
 - [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) - Curated list of awesome self hosted software (290,872★).
+- [awesome-unifi](https://github.com/wolffcatskyy/awesome-unifi) - Curated list of awesome UniFi and Ubiquiti networking tools, libraries, and resources (32★).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -549,7 +549,6 @@ _Like this list, but for adjacent topics? The lists below cover broader smart-ho
 - [awesome-iot](https://github.com/HQarroum/awesome-iot) - Curated list of awesome Internet of Things projects and resources (3,928★).
 - [awesome-mqtt](https://github.com/awesome-mqtt/awesome-mqtt#readme) - Curated list of MQTT related stuff (2,332★).
 - [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) - Curated list of awesome self hosted software (290,872★).
-- [awesome-unifi](https://github.com/wolffcatskyy/awesome-unifi) - Curated list of awesome UniFi and Ubiquiti networking tools, libraries, and resources (32★).
 
 ## Contributing
 


### PR DESCRIPTION
First batch from processing the existing PR queue.

## What's added

### Mushroom Strategy → Dashboards & UI / Alternative Dashboards

[`DigiLive/mushroom-strategy`](https://github.com/DigiLive/mushroom-strategy), 640★, very active. Auto-generates a full Home Assistant dashboard from your entities using Mushroom cards.

Originally proposed in #529 against `AalianKhan/mushroom-strategy`. That repo has since moved (the path 404s); `DigiLive` is the current maintainer, so the URL is updated. `bbrks` is credited via `Co-authored-by` for surfacing the project.

## What was deferred

- **`wolffcatskyy/awesome-unifi`** (#651): the listing-check enforces a 6-month minimum age for cross-referenced awesome-lists, and the repo was created 2026-02-16 (under 3 months at the time of CI). Closing #651 separately with a note inviting the contributor to reopen once the repo has aged past the threshold.
- **`momenbasel/awesome-mac-mini-homeserver`** (#663): closed earlier in this queue sweep — only 3★ and 17 days old.

## Verification

- Target repo verified live and active via the GitHub search API.
- Repo URL for Mushroom Strategy updated from the (404) original to the current canonical maintainer.
- Listing-check, awesome-lint, and Netlify deploy preview all pass after dropping awesome-unifi.

Closes #529.