### PR TITLE
Drop "feature requests" claim from the forum entry (closes #655)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ to join.
 ### Official Communities
 
 - [Home Assistant Discord](https://discordapp.com/invite/c5DvZ4e) - Join the chat, most of us are there.
-- [Home Assistant Community](https://community.home-assistant.io/?u=frenck) - The discussion forum, also used for feature requests.
+- [Home Assistant Community](https://community.home-assistant.io/?u=frenck) - The community discussion forum.
 - [Home Assistant Subreddit](https://www.reddit.com/r/homeassistant/) - If you are into Reddit, subscribe.
 - [Home Assistant Facebook Group](https://www.facebook.com/groups/HomeAssistant/) - Facebook group for enthusiasts.
 


### PR DESCRIPTION
Issue #655 flagged that the `Home Assistant Community` line in `Official Communities` describes the discussion forum as "also used for feature requests", which has been a moving target for a while.

Switching the description to a generic "The community discussion forum." Avoids making stale claims about where feature requests officially go without losing the entry's purpose.

One-line README change.

Closes #655.