### PR TITLE
Add SmartHomeScene to Online Resources / Blogs (closes #429)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ _Home Assistant has a thriving community of bloggers, YouTubers, podcasters, and
 - [Tinkering with Home Automation](https://blog.ceard.tech/) - Tinkerer's blog and guides.
 - [HomeTechHacker](https://HomeTechHacker.com) - DIY Smarthome guides, reviews, and advice.
 - [Intermittent Technology](https://blog.quindorian.org) - Quindor's personal blog for pasting random (mostly technology related) things.
-- [SmartHomeScene](https://smarthomescene.com/) - Beginner-friendly Home Assistant tutorials, smart-home device reviews, and DIY automation projects.
+- [SmartHomeScene](https://smarthomescene.com/) - Beginner-friendly tutorials, smart-home device reviews, and DIY automation projects.
 
 ### YouTube Channels
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ _Home Assistant has a thriving community of bloggers, YouTubers, podcasters, and
 - [Tinkering with Home Automation](https://blog.ceard.tech/) - Tinkerer's blog and guides.
 - [HomeTechHacker](https://HomeTechHacker.com) - DIY Smarthome guides, reviews, and advice.
 - [Intermittent Technology](https://blog.quindorian.org) - Quindor's personal blog for pasting random (mostly technology related) things.
+- [SmartHomeScene](https://smarthomescene.com/) - Beginner-friendly Home Assistant tutorials, smart-home device reviews, and DIY automation projects.
 
 ### YouTube Channels
 


### PR DESCRIPTION
Adds [SmartHomeScene](https://smarthomescene.com/) to `Online Resources` → `Blogs`.

## Verification

- Site is live and active: latest posts dated today (2026-05-08), 40+ Home Assistant mentions on the homepage, dedicated tutorials and reviews covering Zigbee, Matter, and Thread.
- Description framed for newer Home Assistant users.

Originally proposed in #429 (2022) by @kiselio. Closing the issue via this PR; the contributor is credited via `Co-authored-by`.

Closes #429.