### PR TITLE
Add CODESYS V3 Home Automation to DIY / Standalone projects (closes #436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ _Some of the best smart-home gadgets do not exist as products you can buy, but o
 - [ESPHome](https://esphome.io/) - Program ESP8266 boards and ESP32 boards using YAML.
 - [Tasmota](https://github.com/arendst/Tasmota) - Firmware for ESP8266 boards and devices (24,346★).
 - [Sonoff NSPanel](https://github.com/joBr99/nspanel-lovelace-ui) - Custom firmware for Sonoff NSPanel touchscreens with a Lovelace-style UI (986★).
+- [CODESYS V3 Home Automation](https://github.com/MichielVanwelsenaere/HomeAutomation.CoDeSys3) - PLC home-automation software that communicates over MQTT for wired automation setups (142★).
 
 ### DIY Gateways
 


### PR DESCRIPTION
Adds [`MichielVanwelsenaere/HomeAutomation.CoDeSys3`](https://github.com/MichielVanwelsenaere/HomeAutomation.CoDeSys3) to `DIY` → `Standalone projects`. PLC-based home automation that bridges to HA via MQTT, niche but established and well-suited to wired-automation setups.

## Verification

- 142★, MIT, created 2019-06-14, last push 2026-04-02. Passes the listing-check criteria (≥6 months age, OSI license, recent push).
- Original PR (#436) was opened in 2022 by `MichielVanwelsenaere`. Crediting via `Co-authored-by`.

Closes #436.