### PR TITLE
Update Smart Home Junkie YouTube URL to handle (closes #424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ _Sit back, relax, watch, and learn._
 - [digiblurDIY](https://www.youtube.com/channel/UC5ZdPKE2ckcBhljTc2R_qNA) - Tutorials on hardware projects and Tasmota automations.
 - [Intermit.Tech](https://www.youtube.com/channel/UCv7UOhZ2XuPwm9SN5oJsCjA) - Tutorials & reviews: Camera's, Home Networking, ESP8266 boards, Node-RED.
 - [BeardedTinker](https://www.youtube.com/channel/UCuqokNoK8ZFNQdXxvlE129g) - Tutorials & 3D printing.
-- [Smart Home Junkie](https://www.youtube.com/channel/UCVtQ4AOSmCFUuvixddYiSxw/) - How-to videos and tutorials for starters and advanced users.
+- [Smart Home Junkie](https://www.youtube.com/@smarthomejunkie) - How-to videos and tutorials for starters and advanced users.
 - [Everything Smart Home](https://www.youtube.com/c/EverythingSmartHome) - Focuses on Smart Home, Home Automation, general tech reviews, guides, and step-by-step DIY projects.
 
 ### Podcasts


### PR DESCRIPTION
Swaps the Smart Home Junkie entry in `Online Resources` → `YouTube Channels` from the opaque channel-ID URL to the current handle URL `youtube.com/@smarthomejunkie`.

Verified the handle resolves to the same channel ("Smart Home Junkie - YouTube"). One-line change.

Originally proposed in #424 by the channel owner; credited via `Co-authored-by`.

Closes #424.