### PR TITLE
Refresh FUNDING.yml to match current personal projects

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 ---
-# github: frenck
+github: frenck
 patreon: frenck
-ko_fi: frenck
 custom: https://frenck.dev/donate/


### PR DESCRIPTION
## What

Sync `.github/FUNDING.yml` with the pattern Frenck uses across his other active personal projects (e.g. `hassio-addons/addon-ssh`).

## Diff

```diff
 ---
-# github: frenck
+github: frenck
 patreon: frenck
-ko_fi: frenck
 custom: https://frenck.dev/donate/
```

- **Activate GitHub Sponsors** — the `github:` line was commented out, so the Sponsor button on this repo never linked anywhere.
- **Drop ko-fi** — current personal projects no longer list ko-fi; consolidating on GitHub Sponsors + Patreon + the donate page keeps the list short and avoids dead links if ko-fi ever lapses.
- **Keep Patreon and the donate page** — both still active.

## Test plan

- [ ] After merge, GitHub renders a "Sponsor" button at the top of the repo with the listed options.
