### PR TITLE
Add Dependabot cooldown windows and group minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,39 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Two improvements to `.github/dependabot.yml`:

1. **Add cooldown windows.** Newly-released versions are not picked up immediately; Dependabot waits long enough for the broader ecosystem to surface regressions or compromised releases. Concretely:
   - **pip**: 3-day patch / 7-day minor / 14-day major / 5-day default
   - **github-actions**: 7-day default (gh-actions doesn't expose semver fields)

2. **Group minor and patch updates.** Instead of one PR per dependency, Dependabot will open a single weekly PR per ecosystem covering all minor + patch bumps. Major upgrades stay individual so they can still be reviewed on their own.

I also moved the schedule from daily to weekly (Monday 06:00). With the cooldown in place daily checks no longer make sense — the bot would just sit on the same window every day.

## Why

- **Cooldown** narrows the window where a freshly-published, compromised, or broken release could land in this repo before anyone has noticed in the wider ecosystem. It's a low-cost mitigation against supply-chain attacks of the npm/PyPI variety, and a positive signal for OpenSSF Scorecard / supply-chain-hygiene reviews.
- **Grouped updates** sharply cut PR noise (mkdocs-material alone publishes minor versions weekly) without sacrificing visibility on majors.

## Ecosystems covered

- `pip` — `requirements.txt`
- `github-actions` — `.github/workflows/`

No other ecosystems are present in this repo (no `package.json`, no `Dockerfile`, no `Gemfile`).

## Test plan

- [ ] Validate the file with `gh dependabot config validate` or by waiting for Dependabot's "Insights" tab to confirm the new config is parsed.
- [ ] Confirm the next weekly run produces grouped PRs rather than per-package PRs.
