### PR TITLE
Expand Trademark Legal Notice with OHF attribution and license clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,11 +579,18 @@ Thank you for being involved! 😍
 
 ## Trademark Legal Notice
 
-This Awesome list is not created, developed, affiliated, supported, maintained
-or endorsed by Home Assistant.
+Awesome Home Assistant is an independent, community-curated index. It is not
+created, endorsed, sponsored by, or affiliated with
+[Home Assistant](https://www.home-assistant.io) or the
+[Open Home Foundation](https://www.openhomefoundation.org). "Home Assistant"
+and the Home Assistant logo are trademarks of the Open Home Foundation.
 
-All product names, logos, brands, trademarks and registered trademarks are
-property of their respective owners. All company, product, and service names
-used in this list are for identification purposes only.
+All other product names, logos, brands, trademarks, and registered trademarks
+referenced in this list are the property of their respective owners.
+References to specific manufacturers, products, integrations, add-ons,
+services, and community projects are for identification purposes only and do
+not imply endorsement by their owners.
 
-Use of these names, logos, trademarks, and brands does not imply endorsement.
+The contents of this list are licensed under [Creative Commons Attribution
+4.0 International](https://creativecommons.org/licenses/by/4.0/) (CC-BY-4.0).
+See [LICENSE.md](LICENSE.md) for the full text.


### PR DESCRIPTION
## What

Rewrite of the Trademark Legal Notice section. Three substantive additions on top of the existing wording:

1. **Name the trademark holder correctly.** Home Assistant trademarks are owned by the Open Home Foundation, not by "Home Assistant" the brand. The new text says so explicitly.
2. **Cover affiliation broadly.** "Not endorsed by Home Assistant" was the old phrasing; the new text covers Home Assistant *and* the Open Home Foundation, and uses the standard "not affiliated, endorsed, or sponsored" language so there is no ambiguity about commercial relationships.
3. **Add a license clause.** The list is licensed CC-BY-4.0 (see `LICENSE.md`), but until now nothing in the README told a reader that. Adding it here means anyone who reads only the legal notice still walks away knowing how the content can be reused.

I also tightened "All product names, logos, brands, trademarks and registered trademarks are property of their respective owners" — the new wording is "All other product names ..." which reads correctly now that the paragraph above already covers the Home Assistant marks.

## Diff (just the section)

```diff
 ## Trademark Legal Notice

-This Awesome list is not created, developed, affiliated, supported, maintained
-or endorsed by Home Assistant.
-
-All product names, logos, brands, trademarks and registered trademarks are
-property of their respective owners. All company, product, and service names
-used in this list are for identification purposes only.
-
-Use of these names, logos, trademarks, and brands does not imply endorsement.
+Awesome Home Assistant is an independent, community-curated index. It is not
+created, endorsed, sponsored by, or affiliated with
+[Home Assistant](https://www.home-assistant.io) or the
+[Open Home Foundation](https://www.openhomefoundation.org). "Home Assistant"
+and the Home Assistant logo are trademarks of the Open Home Foundation.
+
+All other product names, logos, brands, trademarks, and registered trademarks
+referenced in this list are the property of their respective owners.
+References to specific manufacturers, products, integrations, add-ons,
+services, and community projects are for identification purposes only and do
+not imply endorsement by their owners.
+
+The contents of this list are licensed under [Creative Commons Attribution
+4.0 International](https://creativecommons.org/licenses/by/4.0/) (CC-BY-4.0).
+See [LICENSE.md](LICENSE.md) for the full text.
```

Note: this PR assumes `LICENSE.md` is at the repo root (PR #697). If that one is merged in a different shape, the link target needs a one-line tweak.

## Test plan

- [ ] `awesome-lint` passes.
- [ ] No broken links (lychee).
- [ ] The link to `LICENSE.md` resolves once #697 is merged.
