### PR TITLE
Fix listing-check workflow on PRs from forks

### DIFF
--- a/.github/workflows/listing-check-comment.yaml
+++ b/.github/workflows/listing-check-comment.yaml
@@ -1,0 +1,54 @@
+---
+# Posts the report produced by "Listing check" as a sticky comment on the
+# pull request. Runs on workflow_run so it executes in the base repository
+# context with write permissions, which is required when the originating
+# pull request comes from a fork.
+
+name: Listing check comment
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_run:
+    workflows: ["Listing check"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    name: Post or update PR comment
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Download report artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: listing-check-report
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          number=$(cat artifact/pr-number.txt)
+          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: $number" >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: listing-check
+          number: ${{ steps.pr.outputs.number }}
+          path: artifact/report.md

--- a/.github/workflows/listing-check.yaml
+++ b/.github/workflows/listing-check.yaml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,12 +45,19 @@ jobs:
             > report.md
           cat report.md
 
-      - name: Post or update PR comment
+      - name: Save PR number for follow-up comment workflow
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload report and PR number
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          header: listing-check
-          path: report.md
+          name: listing-check-report
+          path: |
+            report.md
+            pr-number.txt
+          retention-days: 1
 
       - name: Fail job if validator reported errors
         if: github.event_name == 'pull_request' && steps.pr_check.outcome == 'failure'


### PR DESCRIPTION
## What

Splits the `Listing check` workflow into two so that the sticky PR comment also gets posted on pull requests from forks (which is most external contributions).

## Why

PRs #704 and #705 (both from a fork) hit this on the new workflow:

```
##[error]Resource not accessible by integration
https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

The validation itself ran fine — both reported `✅ All checks passed`. The failure was in the next step where `marocchino/sticky-pull-request-comment` tried to post the report.

This is the well-known `pull_request` + fork constraint: GitHub forces `GITHUB_TOKEN` to read-only on workflows triggered by a fork PR, no matter what the `permissions:` block declares. So the workflow can read, but it can't write a comment on the base repo.

## How

The standard split-workflow pattern, which keeps any code from the fork running with read-only privileges and leaves all write actions to a separate, base-repo-controlled workflow.

1. **`listing-check.yaml`** keeps running on `pull_request`, but no longer posts a comment. It uploads `report.md` (and the PR number) as an artifact, then fails the job if the validator found errors. The job's pass/fail is what shows up as the PR's status check.

2. **`listing-check-comment.yaml`** (new) runs on `workflow_run` after `Listing check` completes. Because `workflow_run` always executes in the base repo's context, it gets `pull-requests: write` for real. It downloads the artifact and posts/updates the sticky comment.

## Notes

- No code from the PR is executed by the `workflow_run` workflow; it only reads the artifact (`report.md` + `pr-number.txt`) that the first workflow produced.
- PR number is validated to be numeric before being passed to the comment action — defense against a hostile contributor stuffing markup into the artifact.
- Status check on the PR (✓/✗) comes from the first workflow as before. Only the comment is now delivered async by the second workflow.

## Test plan

- [ ] After merge, re-run on PRs #704 and #705 and confirm a sticky comment appears with the validation report.
- [ ] Trigger a no-change PR from this same repo (not a fork) to confirm the same path works for non-fork PRs.
- [ ] Confirm the scheduled / manual-dispatch path (full sweep, opens an issue on errors) still works — it didn't change.
