### PR TITLE
Auto-label PRs based on README diff content

### DIFF
--- a/.github/workflows/auto-label-apply.yaml
+++ b/.github/workflows/auto-label-apply.yaml
@@ -1,0 +1,120 @@
+---
+# Reconciles the labels on a pull request based on the desired-label list
+# produced by Auto-label compute. Runs on workflow_run so it executes in
+# the base repository's context with pull-requests: write, even for PRs
+# from forks. Reads only the artifact (labels.txt + pr-number.txt) -- no
+# code from the originating PR is executed here.
+
+name: Auto-label apply
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_run:
+    workflows: ["Auto-label compute"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply / remove managed labels
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Download payload artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: auto-label-payload
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from pathlib import Path
+
+          REPO = os.environ["REPO"]
+          TOKEN = os.environ["GH_TOKEN"]
+
+          MANAGED = {
+              "💖 new",
+              "❤️‍🔥 remove",
+              "❤️‍🩹 update",
+              "github_actions",
+              "dependencies",
+          }
+
+          number_text = Path("artifact/pr-number.txt").read_text().strip()
+          if not number_text.isdigit():
+              raise SystemExit(f"Refusing non-numeric PR number: {number_text!r}")
+          pr = int(number_text)
+
+          desired_raw = Path("artifact/labels.txt").read_text().splitlines()
+          desired = {line.strip() for line in desired_raw if line.strip()}
+          # Belt-and-suspenders: only operate on labels we own. Anything else
+          # in the artifact is silently dropped.
+          desired &= MANAGED
+
+          print(f"PR #{pr}")
+          print(f"Desired (managed) labels: {sorted(desired)}")
+
+
+          def api(method, path, body=None):
+              req = urllib.request.Request(
+                  f"https://api.github.com{path}",
+                  method=method,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {TOKEN}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                      "User-Agent": "auto-label-workflow",
+                  },
+                  data=json.dumps(body).encode() if body is not None else None,
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read() or "null")
+              except urllib.error.HTTPError as e:
+                  print(f"HTTP {e.code} on {method} {path}: {e.read().decode()}")
+                  raise
+
+
+          current = {
+              lbl["name"]
+              for lbl in api("GET", f"/repos/{REPO}/issues/{pr}/labels")
+          }
+          print(f"Current labels: {sorted(current)}")
+
+          to_add = desired - current
+          to_remove = (current & MANAGED) - desired
+
+          if to_add:
+              print(f"Adding: {sorted(to_add)}")
+              api(
+                  "POST",
+                  f"/repos/{REPO}/issues/{pr}/labels",
+                  {"labels": sorted(to_add)},
+              )
+
+          for label in sorted(to_remove):
+              print(f"Removing: {label}")
+              encoded = urllib.parse.quote(label, safe="")
+              api("DELETE", f"/repos/{REPO}/issues/{pr}/labels/{encoded}")
+          PY

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -54,6 +54,7 @@ jobs:
           import re
           import subprocess
           import urllib.error
+          import urllib.parse
           import urllib.request
 
           BASE = os.environ["BASE_REF"]
@@ -62,9 +63,9 @@ jobs:
           TOKEN = os.environ["GH_TOKEN"]
 
           MANAGED = {
-              "\U0001f496 new",          # 💖 new
-              "❤️‍\U0001f525 remove",  # ❤️‍🔥 remove
-              "❤️‍\U0001fa79 update",  # ❤️‍🩹 update
+              "💖 new",
+              "❤️‍🔥 remove",
+              "❤️‍🩹 update",
               "github_actions",
               "dependencies",
           }
@@ -107,11 +108,11 @@ jobs:
 
           desired = set()
           if added_urls - removed_urls:
-              desired.add("\U0001f496 new")
+              desired.add("💖 new")
           if removed_urls - added_urls:
-              desired.add("❤️‍\U0001f525 remove")
+              desired.add("❤️‍🔥 remove")
           if added_urls & removed_urls:
-              desired.add("❤️‍\U0001fa79 update")
+              desired.add("❤️‍🩹 update")
 
           files = changed_files()
           if any(f.startswith(".github/workflows/") for f in files):

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,74 +1,44 @@
 ---
-# Reads the PR diff and applies / removes a fixed set of "managed" labels:
-#   - 💖 new       : at least one new entry added to the README
-#   - ❤️‍🔥 remove   : at least one entry removed from the README
-#   - ❤️‍🩹 update   : an entry changed in place (same URL, different text)
-#   - github_actions: workflow files changed
-#   - dependencies  : requirements.txt changed
-#
-# Runs on pull_request_target so it can write labels even on PRs from forks
-# (the standard pull_request event drops to read-only on fork PRs). Code
-# from the PR is never executed; we only diff the head SHA from the base
-# checkout.
+# Computes the set of labels that should be applied to a pull request based
+# on its diff. Runs on the standard pull_request event so the workflow has
+# read-only permissions and never runs in a privileged context, even with
+# fork PRs. Output is uploaded as an artifact and consumed by
+# auto-label-apply.yaml, which has the write permissions needed to mutate
+# labels.
 
-name: Auto-label
+name: Auto-label compute
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
-  label:
-    name: Apply content-based labels
+  compute:
+    name: Compute desired labels
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
-      - name: Check out base for diffing
+      - name: Check out PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Fetch PR head into local ref
+      - name: Classify diff into desired labels
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: git fetch --no-tags --depth=50 origin "pull/${PR_NUMBER}/head:pr-head"
-
-      - name: Reconcile managed labels
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
-          python3 <<'PY'
-          import json
+          python3 <<'PY' > labels.txt
           import os
           import re
           import subprocess
-          import urllib.error
-          import urllib.parse
-          import urllib.request
 
           BASE = os.environ["BASE_REF"]
-          PR = os.environ["PR_NUMBER"]
-          REPO = os.environ["REPO"]
-          TOKEN = os.environ["GH_TOKEN"]
-
-          MANAGED = {
-              "💖 new",
-              "❤️‍🔥 remove",
-              "❤️‍🩹 update",
-              "github_actions",
-              "dependencies",
-          }
 
 
           def run(*args):
@@ -78,11 +48,11 @@ jobs:
 
 
           def diff_for(path):
-              return run("git", "diff", f"origin/{BASE}...pr-head", "--", path)
+              return run("git", "diff", f"origin/{BASE}...HEAD", "--", path)
 
 
           def changed_files():
-              out = run("git", "diff", "--name-only", f"origin/{BASE}...pr-head")
+              out = run("git", "diff", "--name-only", f"origin/{BASE}...HEAD")
               return [f for f in out.splitlines() if f]
 
 
@@ -94,7 +64,6 @@ jobs:
           added_urls = set()
           removed_urls = set()
           for line in diff_for("README.md").splitlines():
-              # Skip diff header lines that start with +++ or ---.
               if line.startswith(("+++", "---")):
                   continue
               match = ENTRY_PATTERN.match(line)
@@ -123,48 +92,22 @@ jobs:
           ):
               desired.add("dependencies")
 
-          print(f"Desired labels: {sorted(desired)}")
-
-
-          def api(method, path, body=None):
-              req = urllib.request.Request(
-                  f"https://api.github.com{path}",
-                  method=method,
-                  headers={
-                      "Accept": "application/vnd.github+json",
-                      "Authorization": f"Bearer {TOKEN}",
-                      "X-GitHub-Api-Version": "2022-11-28",
-                      "User-Agent": "auto-label-workflow",
-                  },
-                  data=json.dumps(body).encode() if body is not None else None,
-              )
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      return json.loads(r.read() or "null")
-              except urllib.error.HTTPError as e:
-                  print(f"HTTP {e.code} on {method} {path}: {e.read().decode()}")
-                  raise
-
-
-          current = {
-              lbl["name"]
-              for lbl in api("GET", f"/repos/{REPO}/issues/{PR}/labels")
-          }
-          print(f"Current labels: {sorted(current)}")
-
-          to_add = desired - current
-          to_remove = (current & MANAGED) - desired
-
-          if to_add:
-              print(f"Adding: {sorted(to_add)}")
-              api(
-                  "POST",
-                  f"/repos/{REPO}/issues/{PR}/labels",
-                  {"labels": sorted(to_add)},
-              )
-
-          for label in sorted(to_remove):
-              print(f"Removing: {label}")
-              encoded = urllib.parse.quote(label, safe="")
-              api("DELETE", f"/repos/{REPO}/issues/{PR}/labels/{encoded}")
+          for label in sorted(desired):
+              print(label)
           PY
+          echo "----- desired labels -----"
+          cat labels.txt
+
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
+
+      - name: Upload payload for follow-up workflow
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: auto-label-payload
+          path: |
+            labels.txt
+            pr-number.txt
+          retention-days: 1

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,0 +1,169 @@
+---
+# Reads the PR diff and applies / removes a fixed set of "managed" labels:
+#   - 💖 new       : at least one new entry added to the README
+#   - ❤️‍🔥 remove   : at least one entry removed from the README
+#   - ❤️‍🩹 update   : an entry changed in place (same URL, different text)
+#   - github_actions: workflow files changed
+#   - dependencies  : requirements.txt changed
+#
+# Runs on pull_request_target so it can write labels even on PRs from forks
+# (the standard pull_request event drops to read-only on fork PRs). Code
+# from the PR is never executed; we only diff the head SHA from the base
+# checkout.
+
+name: Auto-label
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Apply content-based labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out base for diffing
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR head into local ref
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags --depth=50 origin "pull/${PR_NUMBER}/head:pr-head"
+
+      - name: Reconcile managed labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import urllib.error
+          import urllib.request
+
+          BASE = os.environ["BASE_REF"]
+          PR = os.environ["PR_NUMBER"]
+          REPO = os.environ["REPO"]
+          TOKEN = os.environ["GH_TOKEN"]
+
+          MANAGED = {
+              "\U0001f496 new",          # 💖 new
+              "❤️‍\U0001f525 remove",  # ❤️‍🔥 remove
+              "❤️‍\U0001fa79 update",  # ❤️‍🩹 update
+              "github_actions",
+              "dependencies",
+          }
+
+
+          def run(*args):
+              return subprocess.run(
+                  args, capture_output=True, text=True, check=True
+              ).stdout
+
+
+          def diff_for(path):
+              return run("git", "diff", f"origin/{BASE}...pr-head", "--", path)
+
+
+          def changed_files():
+              out = run("git", "diff", "--name-only", f"origin/{BASE}...pr-head")
+              return [f for f in out.splitlines() if f]
+
+
+          # Bullet-style entry: "- [Display](url) - description ..."
+          ENTRY_PATTERN = re.compile(
+              r"^[+-]\s*-\s*\[[^\]]+\]\((https?://[^\s)]+)\)"
+          )
+
+          added_urls = set()
+          removed_urls = set()
+          for line in diff_for("README.md").splitlines():
+              # Skip diff header lines that start with +++ or ---.
+              if line.startswith(("+++", "---")):
+                  continue
+              match = ENTRY_PATTERN.match(line)
+              if not match:
+                  continue
+              url = match.group(1)
+              if line.startswith("+"):
+                  added_urls.add(url)
+              elif line.startswith("-"):
+                  removed_urls.add(url)
+
+          desired = set()
+          if added_urls - removed_urls:
+              desired.add("\U0001f496 new")
+          if removed_urls - added_urls:
+              desired.add("❤️‍\U0001f525 remove")
+          if added_urls & removed_urls:
+              desired.add("❤️‍\U0001fa79 update")
+
+          files = changed_files()
+          if any(f.startswith(".github/workflows/") for f in files):
+              desired.add("github_actions")
+          if any(
+              f == "requirements.txt" or f.endswith("/requirements.txt")
+              for f in files
+          ):
+              desired.add("dependencies")
+
+          print(f"Desired labels: {sorted(desired)}")
+
+
+          def api(method, path, body=None):
+              req = urllib.request.Request(
+                  f"https://api.github.com{path}",
+                  method=method,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {TOKEN}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                      "User-Agent": "auto-label-workflow",
+                  },
+                  data=json.dumps(body).encode() if body is not None else None,
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read() or "null")
+              except urllib.error.HTTPError as e:
+                  print(f"HTTP {e.code} on {method} {path}: {e.read().decode()}")
+                  raise
+
+
+          current = {
+              lbl["name"]
+              for lbl in api("GET", f"/repos/{REPO}/issues/{PR}/labels")
+          }
+          print(f"Current labels: {sorted(current)}")
+
+          to_add = desired - current
+          to_remove = (current & MANAGED) - desired
+
+          if to_add:
+              print(f"Adding: {sorted(to_add)}")
+              api(
+                  "POST",
+                  f"/repos/{REPO}/issues/{PR}/labels",
+                  {"labels": sorted(to_add)},
+              )
+
+          for label in sorted(to_remove):
+              print(f"Removing: {label}")
+              encoded = urllib.parse.quote(label, safe="")
+              api("DELETE", f"/repos/{REPO}/issues/{PR}/labels/{encoded}")
+          PY


### PR DESCRIPTION
## What

Adds two workflows that together apply (and remove) a fixed set of
labels on every pull request based on its diff:

| Label | When it's applied |
|---|---|
| `💖 new` | At least one URL appears in added entry-style lines but not in removed ones |
| `❤️‍🔥 remove` | At least one URL appears in removed lines but not in added ones |
| `❤️‍🩹 update` | The same URL appears in both added and removed lines (entry edited in place) |
| `github_actions` | A file under `.github/workflows/` changed |
| `dependencies` | `requirements.txt` changed |

A single PR can earn several labels (e.g. `💖 new` + `❤️‍🔥 remove` if the change
both adds and removes entries; `update` is reserved for URL-preserving
edits).

The five labels above are the workflow's "managed" set. On every sync
the workflow reconciles state: missing-but-desired labels are added,
present-but-no-longer-desired managed labels are removed. Labels
applied by humans (e.g. `wontfix`, `good first issue`) are never
touched.

## Two-stage workflow

CodeQL flagged a single-workflow `pull_request_target` design as
`actions/untrusted-checkout/high` — a conservative heuristic that fires
on any combination of `pull_request_target` + `actions/checkout`, even
when the checkout target is `base.ref`. The recommended fix, which is
also what `Listing check` does after #706, is the two-stage split:

1. **`Auto-label compute`** — `.github/workflows/auto-label.yaml`,
   triggered on `pull_request`. Runs with read-only token, in the
   PR's checkout. Computes the desired label set from the diff, writes
   `labels.txt` and `pr-number.txt`, and uploads them as the
   `auto-label-payload` artifact. No write access to anything.

2. **`Auto-label apply`** — `.github/workflows/auto-label-apply.yaml`,
   triggered on `workflow_run` when stage 1 completes. Runs in the base
   repository's context with `pull-requests: write`, downloads the
   artifact, validates that the PR number is numeric, and reconciles
   labels via the GitHub API. No code from the originating PR is
   executed in this workflow.

Stage 2 also intersects the desired-label set with the hard-coded
`MANAGED` set as a belt-and-suspenders check, so even if the artifact
were tampered with, the workflow can only ever toggle labels we own.

## How the diff is classified

A bullet-style entry on the list looks like:

```
- [Display Name](https://example.com/path) - description ...
```

The compute workflow regex-matches that pattern across `+`/`-` lines in
the README diff, extracts the URL from each match, and groups them into
`added_urls` and `removed_urls` sets. From there:

- `added - removed` → `💖 new`
- `removed - added` → `❤️‍🔥 remove`
- `added & removed` → `❤️‍🩹 update`

Section reorders that move a line without changing it produce both an
add and a remove of the same URL, which gets classified as `update`.
That's the right behaviour: a section reorder *is* an update from the
list's perspective even if the entry text is identical.

## Test plan

Once merged, both workflows will fire on every existing open PR's next
sync. Specifically I expect:

- [ ] PR #704 (adds Ryan Warner's public configuration) → `💖 new`
- [ ] PR #705 (adds Warner Discovers YouTube channel) → `💖 new`
- [ ] PRs #700, #701, #702, #703, #706, #707 (config-only changes) →
  no labels except `github_actions` where a workflow changed
- [ ] A future Dependabot PR bumping `mkdocs-material` →
  `dependencies` (and `github_actions` if it touches an action pin)
- [ ] CodeQL `actions/untrusted-checkout/high` alert clears on this PR.
