### PR TITLE
Add 50 popular HACS entries (batch 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ _Integrations Home Assistant does not ship with out of the box, written by the c
 _Wire Home Assistant up to a large language model and let it read your devices, build dashboards, write automations, or describe what your cameras see._
 
 - [LLM Vision](https://github.com/valentinfrlch/ha-llmvision) - Add visual intelligence to your automations: caption camera snapshots, summarize what is happening, react to specific events (1,325★).
+- [AI Automation Suggester](https://github.com/ITSpecialist111/ai_automation_suggester) - Scan your entities and ask an AI provider (OpenAI, Anthropic, Google, Groq, Ollama) for tailored automation suggestions, surfaced as notifications (721★).
 
 ### 💡 Lighting
 
@@ -205,6 +206,7 @@ _Effects, schedules, and behaviour layers that sit on top of your lights._
 
 - [Circadian Lighting](https://github.com/claytonjn/hass-circadian_lighting) - Slowly synchronizes your color-changing lights with the naturally occurring color temperature of the sky throughout the day (882★).
 - [Adaptive Lighting](https://github.com/basnijholt/adaptive-lighting) - Slowly adjust the brightness and color temperature of your lights based on the position of the sun (3,279★).
+- [Govee](https://github.com/LaggAt/hacs-govee) - Local control of Govee Wi-Fi lights and bulbs, including effects and color modes (349★).
 
 ### 🌡️ Climate
 
@@ -212,12 +214,20 @@ _Smarter thermostats, comfort sensors, and HVAC integrations that go beyond what
 
 - [Better Thermostat](https://github.com/KartoffelToby/better_thermostat) - Smarter thermostat with window detection, heating curves, and per-room comfort profiles for thermostatic radiator valves (1,389★).
 - [Versatile Thermostat](https://github.com/jmcollin78/versatile_thermostat) - Full-featured thermostat with presets, window detection, motion-based comfort, and presence (1,040★).
+- [Gree Climate Component](https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent) - Local control of Gree air conditioners and heat pumps without their cloud, including swing, fan modes, and presets (471★).
+- [Midea Air Appliances LAN](https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan) - Local control of Midea air conditioners, dehumidifiers, and other appliances over LAN (451★).
 
 ### ⚡ Energy & solar
 
 _Pull your solar inverter, smart meter, home battery, or utility tariff into Home Assistant and feed the energy dashboard._
 
 - [Powercalc](https://github.com/bramstroker/homeassistant-powercalc) - Calculate estimated power consumption of lights and other devices, even those that don't report it themselves (1,472★).
+- [Anker Solix](https://github.com/thomluther/ha-anker-solix) - Pull Anker Solix balcony solar systems, batteries, and power stations into the energy dashboard with live state, history, and charging control (963★).
+- [Octopus Energy](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy) - Octopus Energy tariffs, smart meter readings, intelligent dispatch slots, and saving sessions, surfaced as sensors (918★).
+- [Huawei Solar](https://github.com/wlcrs/huawei_solar) - Read and control Huawei solar inverters and home batteries over Modbus, including grid charge windows (882★).
+- [SolaX Modbus](https://github.com/wills106/homeassistant-solax-modbus) - Talk to SolaX, Solinteg, Sofar, Growatt, and other inverters over Modbus, including read-only and inverter control modes (484★).
+- [Solarman](https://github.com/davidrapan/ha-solarman) - Read Deye, Sofar, and other Solarman-branded inverters via the Solarman stick logger (462★).
+- [OCPP](https://github.com/lbbrhzn/ocpp) - Bring electric vehicle chargers that speak OCPP into the energy dashboard, with start, stop, and per-session metering (362★).
 
 ### 📹 Cameras & video
 
@@ -228,6 +238,7 @@ _Pair specific camera brands and video sources that Home Assistant does not supp
 - [Frigate](https://github.com/blakeblackshear/frigate-hass-integration) - Integrate the Frigate NVR with local object detection into your dashboard, alerts, and snapshots (1,153★).
 - [Eufy Security](https://github.com/fuatakgun/eufy_security) - Manage Eufy Security cameras, doorbells, and base stations with live streams and event notifications (1,318★).
 - [Tapo Control](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control) - Control TP-Link Tapo cameras with PTZ, motion events, and a live RTSP stream (1,861★).
+- [Dahua](https://github.com/rroller/dahua) - Dahua cameras and doorbells with motion events, snapshots, sirens, and PTZ controls (532★).
 
 ### 🚨 Security & alarm
 
@@ -248,13 +259,17 @@ _Send commands to voice speakers and media players, or relay what they hear and 
 
 _Track your car's battery, location, and charging state, or control where and when it plugs in._
 
-- [Suggest one](https://github.com/frenck/awesome-home-assistant/issues/new/choose) - Have a community resource that fits here? Open an issue to propose it.
+- [Kia Uvo & Hyundai Bluelink](https://github.com/Hyundai-Kia-Connect/kia_uvo) - Track and control Kia Connect (Uvo) and Hyundai Bluelink cars across EU, Canada, and USA, including charging, climate, and lock state (851★).
+- [Tesla](https://github.com/alandtse/tesla) - Tesla cars and Powerwalls with charging, climate, location, and security state, using a refresh token from a third-party login app (725★).
+- [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Volkswagen Carnet integration for charging state, climate preconditioning, and remote lock and honk for Volkswagen cars (512★).
 
 ### 📍 Presence & location
 
 _Figure out who is home and where they are, often more accurately than the built-in device tracker._
 
 - [iCloud3](https://github.com/gcobb321/icloud3) - Improved version of the iCloud device tracker component with a lot of capabilities (835★).
+- [iPhone Detect](https://github.com/mudape/iphonedetect) - Detect iPhones (and other phones) on the local Wi-Fi without an app, by sending a UDP probe and watching for the reply (615★).
+- [Flightradar24](https://github.com/AlexandrErohin/home-assistant-flightradar24) - Track aircraft flying over a configurable bounding box around your home using Flightradar24 (426★).
 
 ### 🧹 Vacuums
 
@@ -286,6 +301,11 @@ _Pull a specific manufacturer's devices into Home Assistant, often with more fea
 - [Xiaomi Gateway 3](https://github.com/AlexxIT/XiaomiGateway3) - Local control of Xiaomi Multimode Gateway and Aqara Hub E1 over LAN, no cloud round-trips (2,745★).
 - [Midea AC LAN](https://github.com/wuwentao/midea_ac_lan) - Local control of Midea air conditioners, heat pumps, and other M-Smart devices (1,616★).
 - [SmartThinQ Sensors](https://github.com/ollo69/ha-smartthinq-sensors) - LG appliances (washers, dryers, AC, fridges) wired up via SmartThinQ with rich state and remote start (1,296★).
+- [Home Connect Alt](https://github.com/ekutner/home-connect-hass) - Alternative Home Connect integration for Bosch, Siemens, NEFF, and Gaggenau ovens, dishwashers, and washing machines, with richer state than the official one (952★).
+- [Tapo Devices](https://github.com/petretiandrea/home-assistant-tapo-p100) - TP-Link Tapo plugs, switches, bulbs, and energy monitoring (P100, P105, P110, L510, L530, L900) over LAN (944★).
+- [Meross](https://github.com/albertogeniola/meross-homeassistant) - Meross plugs, switches, bulbs, garage door openers, and humidifiers via the Meross IoT cloud (846★).
+- [HomeMatic IP Local](https://github.com/SukramJ/homematicip_local) - Local control of HomeMatic and HomeMatic IP devices through OpenCCU or RaspberryMatic, no cloud round-trips (564★).
+- [Nest Protect](https://github.com/iMicknl/ha-nest-protect) - Nest Protect smoke and CO alarms with battery state, recent events, and per-room safety status (456★).
 
 ### 🛠️ Automation tooling
 
@@ -295,18 +315,26 @@ _Helpers that make automations easier to write, debug, and maintain._
 - [Browser Mod](https://github.com/thomasloven/hass-browser_mod) - Turn each browser into a controllable entity: pop up cards, navigate views, play sounds, or detect who is looking at the dashboard (1,730★).
 - [Pyscript](https://github.com/custom-components/pyscript) - Write automations and templates in Python instead of YAML (1,150★).
 - [Spook](https://github.com/frenck/spook) - A toolbox of helpful sensors, services, and templates that surface things the UI normally hides (1,112★).
+- [Scheduler Component](https://github.com/nielsfaber/scheduler-component) - Build weekly schedules for any entity through a card-driven UI, no YAML required (874★).
+- [Node-RED Companion](https://github.com/zachowj/hass-node-red) - Companion component for the node-red-contrib-home-assistant-websocket project that exposes services, sensors, and binary sensors back to your dashboards (568★).
+- [Magic Areas](https://github.com/jseidl/magic-areas) - Auto-build per-room presence, climate, and media area entities, with motion-triggered scenes and bright/dark detection (476★).
+- [Auto Backup](https://github.com/jcwillox/hass-auto-backup) - Automate backups with custom schedules, retention rules, encryption, and uploads to remote storage (455★).
+- [Multiscrape](https://github.com/danieldotnl/ha-multiscrape) - Scrape multiple values (HTML, XML, or JSON) from a page in one request and turn them into sensors (429★).
 
 ### 🏘️ Civic & household
 
 _Local services that turn into sensors and calendars: garbage collection schedules, school holidays, traffic, weather alerts, and similar._
 
-- [Suggest one](https://github.com/frenck/awesome-home-assistant/issues/new/choose) - Have a community resource that fits here? Open an issue to propose it.
+- [Mail and Packages](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages) - Sensors for incoming and delivered packages plus USPS Informed Delivery preview images, all from your existing email account (826★).
+- [Irrigation Unlimited](https://github.com/rgc99/irrigation_unlimited) - Irrigation controller with multi-zone schedules, sequences, weather adjustments, and manual run support (426★).
+- [Moonraker (Klipper)](https://github.com/marcolivierarsenault/moonraker-home-assistant) - Track Klipper-based 3D printers running Moonraker (Mainsail, Fluidd) with print progress, temperature, and webcam snapshots (462★).
+- [Afvalbeheer](https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer) - Garbage collection schedule sensors for many Dutch and Belgian municipalities, with paper, plastic, and organic streams broken out (368★).
 
 ### 🔐 Network & authentication
 
 _Sign in to Home Assistant with single sign-on, route through a tunnel, or pull network hardware into your dashboard._
 
-- [Suggest one](https://github.com/frenck/awesome-home-assistant/issues/new/choose) - Have a community resource that fits here? Open an issue to propose it.
+- [OIDC Auth](https://github.com/christiaangoossens/hass-oidc-auth) - Sign in with single sign-on through any OpenID Connect provider, including Authelia, Authentik, Keycloak, and Pocket ID (899★).
 
 ### 🔗 Federation & multi-instance
 
@@ -319,6 +347,8 @@ _Link multiple Home Assistant instances together, share entities across homes, o
 _Send Home Assistant data to external systems for long-term storage, richer dashboards, or analysis._
 
 - [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch (164★).
+- [TrueNAS](https://github.com/tomaae/homeassistant-truenas) - TrueNAS Scale and TrueNAS Core stats, datasets, virtual machines, and apps surfaced as sensors and switches (364★).
+- [Monitor Docker](https://github.com/ualex73/monitor_docker) - Watch CPU, memory, network, and uptime for every Docker container on a host, including remote ones, and start or stop them from automations (398★).
 
 ## Dashboard Cards
 
@@ -331,6 +361,7 @@ _Full card collections that change the look and feel of your dashboards. Mushroo
 - [Mushroom](https://github.com/piitaya/lovelace-mushroom) - A complete card collection with a soft, mobile-first aesthetic that you can drop into existing dashboards (4,960★).
 - [Bubble Card](https://github.com/Clooos/Bubble-Card) - Minimalist card collection with a pop-up touch and rich customization (4,173★).
 - [Floorplan](https://github.com/ExperienceLovelace/ha-floorplan) - Map entities onto an SVG of your house and animate them based on state changes (1,523★).
+- [UI Lovelace Minimalist](https://github.com/UI-Lovelace-Minimalist/UI) - Drop-in dashboard collection with a uniform minimalist look across all your views, including ready-made cards and a button card library (2,019★).
 
 ### 📐 Layout helpers
 
@@ -347,6 +378,10 @@ _Cards that change where and how other cards appear: stack, fold, show condition
 - [Fold Entity Row](https://github.com/thomasloven/lovelace-fold-entity-row) - A foldable row that hides extra entities behind a header until clicked (706★).
 - [State Switch](https://github.com/thomasloven/lovelace-state-switch) - Dynamically swap one card for another based on the state of an entity, the time of day, or the user viewing (456★).
 - [Swipe Navigation](https://github.com/zanna-37/hass-swipe-navigation) - Switch between dashboard views with a swipe gesture on mobile (533★).
+- [Custom Card Features](https://github.com/Nerwyn/custom-card-features) - Adds buttons, dropdowns, sliders, spinboxes, selectors, and toggles you can attach to tile cards to call any service (419★).
+- [Custom Sidebar](https://github.com/elchininet/custom-sidebar) - Personalise the sidebar per user or device, hide pages, reorder them, or restyle the look (271★).
+- [Paper Buttons Row](https://github.com/jcwillox/lovelace-paper-buttons-row) - Highly configurable button rows that can call actions, fire haptics, and restyle per state (359★).
+- [Streamline Card](https://github.com/brunosabot/streamline-card) - Define a card template once and reuse it across the dashboard with different entities, no copy-paste YAML (249★).
 
 ### 📈 Charts & graphs
 
@@ -357,6 +392,8 @@ _Visualise sensor data over time. Gauges, line graphs, bars, and Sankey diagrams
 - [Dual Gauge Card](https://github.com/custom-cards/dual-gauge-card) - Shows two gauges in one (220★).
 - [ApexCharts Card](https://github.com/RomRider/apexcharts-card) - Advanced graphs and charts powered by ApexChartsJS with timelines, multi-axis, and event markers (1,769★).
 - [Sankey Chart](https://github.com/MindFreeze/ha-sankey-chart) - Sankey-style flow diagram for visualising power, water, or any other flow across your home (650★).
+- [Modern Circular Gauge](https://github.com/selvalt7/modern-circular-gauge) - Modern-looking circular gauge card with smooth animations, color stops, and template support (264★).
+- [Flex Table Card](https://github.com/custom-cards/flex-table-card) - Highly flexible table card with arbitrary columns, regex-matched entities, and per-row styling, useful for AppDaemon and templated content (265★).
 
 ### 📋 Status & info rows
 
@@ -365,12 +402,16 @@ _Compact rows that pack more information into entity-card style listings._
 - [Slider Entity Row](https://github.com/thomasloven/lovelace-slider-entity-row) - Add a slider to adjust, e.g., the brightness of lights in lovelace entity cards (906★).
 - [Battery State Card](https://github.com/maxwroc/battery-state-card) - List devices with their battery levels in a tidy card, sorted and color-coded (1,235★).
 - [Scheduler Card](https://github.com/nielsfaber/scheduler-card) - Build and edit weekly schedules for any entity right from the dashboard (1,220★).
+- [Entity Progress Card](https://github.com/francois-le-ko4la/lovelace-entity-progress-card) - Progress-bar card for any numeric entity, with thresholds, gradients, and templated icons (250★).
+- [Vehicle Status Card](https://github.com/ngocjohn/vehicle-status-card) - Vehicle dashboard card showing fuel or charge level, range, doors, lock state, and a customizable image of the car (251★).
 
 ### ☀️ Weather cards
 
 _Weather widgets with the look you actually want._
 
 - [Weather Chart Card](https://github.com/mlamberts78/weather-chart-card) - Weather card with a chart-style hourly forecast and customizable layout (435★).
+- [Hourly Weather](https://github.com/decompil3d/lovelace-hourly-weather) - Hourly weather as a colored horizontal bar so you can see at a glance when conditions change today (387★).
+- [Weather Radar](https://github.com/Makin-Things/weather-radar-card) - Animated rain radar card using the public RainViewer tile service, with country-level and regional zoom (360★).
 
 ### 🎵 Media cards
 
@@ -384,18 +425,21 @@ _Replacement thermostat cards with a different look or feel._
 
 - [Thermostat Card](https://github.com/ciotlosm/lovelace-thermostat-dark-card) - Thermostat control card that looks like a Nest Thermostat (744★).
 - [Simple Thermostat](https://github.com/nervetattoo/simple-thermostat) - A simpler and more flexible thermostat card (807★).
+- [Mini Climate](https://github.com/artem-sedykh/mini-climate-card) - Compact climate card with current temperature, target, and per-mode controls, sized for small dashboards and mobile (318★).
 
 ### ⚡ Energy cards
 
 _Visualise solar production, grid imports, battery state, and consumption flow._
 
-- [Suggest one](https://github.com/frenck/awesome-home-assistant/issues/new/choose) - Have a community resource that fits here? Open an issue to propose it.
+- [Sunsynk Power Flow](https://github.com/slipx06/sunsynk-power-flow-card) - Visualise the live energy flow of Sunsynk and Deye inverters, mirroring the layout of the inverter screen (369★).
 
 ### 💡 Lighting cards
 
 _Specialised controls for lights, color temperature, and effects._
 
 - [RGB Light Card](https://github.com/bokub/rgb-light-card) - Colorful buttons to control your RGB Lights (558★).
+- [Hue-Like Light Card](https://github.com/Gh61/lovelace-hue-like-light-card) - Light card styled and laid out like the Philips Hue app, with grouped scenes and per-bulb control (360★).
+- [Light Entity Card](https://github.com/ljmerza/light-entity-card) - Compact card to control any light or switch entity with brightness, color temperature, and color picker (281★).
 
 ### 🗺️ Maps & location
 
@@ -415,6 +459,7 @@ _Show vacuum status, room maps, and start/stop controls in your dashboard._
 
 - [Vacuum Map Card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card) - This card provides a user-friendly way to fully control Xiaomi (Roborock/Viomi/Dreame/Roidmi) and Neato (+ possibly other) vacuums (1,863★).
 - [Vacuum Card](https://github.com/denysdovhan/vacuum-card) - A card for controlling a robot vacuum (1,199★).
+- [Valetudo Map](https://github.com/Hypfer/lovelace-valetudo-map-card) - Display the live map from a robot vacuum running Valetudo (cloudless firmware) directly on a dashboard (301★).
 
 ### 📅 Calendar & feed
 
@@ -422,6 +467,7 @@ _Calendar views and rolling feeds of upcoming events._
 
 - [Atomic Calendar Revive](https://github.com/totaldebug/atomic-calendar-revive) - Calendar card with advanced settings (611★).
 - [Week Planner Card](https://github.com/FamousWolf/week-planner-card) - Responsive multi-day overview of upcoming events, alarms, and reminders (503★).
+- [Trash Card](https://github.com/idaho/hassio-trash-card) - Show the next trash pickup type (paper, plastic, organic) based on a calendar entity, with color-coded icons (351★).
 
 ### 📡 Remote control
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ _Smarter thermostats, comfort sensors, and HVAC integrations that go beyond what
 
 - [Better Thermostat](https://github.com/KartoffelToby/better_thermostat) - Smarter thermostat with window detection, heating curves, and per-room comfort profiles for thermostatic radiator valves (1,389★).
 - [Versatile Thermostat](https://github.com/jmcollin78/versatile_thermostat) - Full-featured thermostat with presets, window detection, motion-based comfort, and presence (1,040★).
-- [Gree Climate Component](https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent) - Local control of Gree air conditioners and heat pumps without their cloud, including swing, fan modes, and presets (471★).
 - [Midea Air Appliances LAN](https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan) - Local control of Midea air conditioners, dehumidifiers, and other appliances over LAN (451★).
 
 ### ⚡ Energy & solar
@@ -223,7 +222,7 @@ _Pull your solar inverter, smart meter, home battery, or utility tariff into Hom
 
 - [Powercalc](https://github.com/bramstroker/homeassistant-powercalc) - Calculate estimated power consumption of lights and other devices, even those that don't report it themselves (1,472★).
 - [Anker Solix](https://github.com/thomluther/ha-anker-solix) - Pull Anker Solix balcony solar systems, batteries, and power stations into the energy dashboard with live state, history, and charging control (963★).
-- [Octopus Energy](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy) - Octopus Energy tariffs, smart meter readings, intelligent dispatch slots, and saving sessions, surfaced as sensors (918★).
+- [Octopus Energy](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy) - Pull Octopus Energy tariffs, smart meter readings, intelligent dispatch slots, and saving sessions into your dashboard (918★).
 - [Huawei Solar](https://github.com/wlcrs/huawei_solar) - Read and control Huawei solar inverters and home batteries over Modbus, including grid charge windows (882★).
 - [SolaX Modbus](https://github.com/wills106/homeassistant-solax-modbus) - Talk to SolaX, Solinteg, Sofar, Growatt, and other inverters over Modbus, including read-only and inverter control modes (484★).
 - [Solarman](https://github.com/davidrapan/ha-solarman) - Read Deye, Sofar, and other Solarman-branded inverters via the Solarman stick logger (462★).
@@ -238,7 +237,7 @@ _Pair specific camera brands and video sources that Home Assistant does not supp
 - [Frigate](https://github.com/blakeblackshear/frigate-hass-integration) - Integrate the Frigate NVR with local object detection into your dashboard, alerts, and snapshots (1,153★).
 - [Eufy Security](https://github.com/fuatakgun/eufy_security) - Manage Eufy Security cameras, doorbells, and base stations with live streams and event notifications (1,318★).
 - [Tapo Control](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control) - Control TP-Link Tapo cameras with PTZ, motion events, and a live RTSP stream (1,861★).
-- [Dahua](https://github.com/rroller/dahua) - Dahua cameras and doorbells with motion events, snapshots, sirens, and PTZ controls (532★).
+- [Dahua](https://github.com/rroller/dahua) - Pair Dahua cameras and doorbells with motion events, snapshots, sirens, and PTZ controls (532★).
 
 ### 🚨 Security & alarm
 
@@ -260,8 +259,8 @@ _Send commands to voice speakers and media players, or relay what they hear and 
 _Track your car's battery, location, and charging state, or control where and when it plugs in._
 
 - [Kia Uvo & Hyundai Bluelink](https://github.com/Hyundai-Kia-Connect/kia_uvo) - Track and control Kia Connect (Uvo) and Hyundai Bluelink cars across EU, Canada, and USA, including charging, climate, and lock state (851★).
-- [Tesla](https://github.com/alandtse/tesla) - Tesla cars and Powerwalls with charging, climate, location, and security state, using a refresh token from a third-party login app (725★).
-- [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Volkswagen Carnet integration for charging state, climate preconditioning, and remote lock and honk for Volkswagen cars (512★).
+- [Tesla](https://github.com/alandtse/tesla) - Track Tesla cars and Powerwalls with charging, climate, location, and security state, using a refresh token from a third-party login app (725★).
+- [Volkswagen Carnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) - Track charging state, climate preconditioning, and remote lock and honk for Volkswagen cars on the Carnet platform (512★).
 
 ### 📍 Presence & location
 
@@ -303,9 +302,9 @@ _Pull a specific manufacturer's devices into Home Assistant, often with more fea
 - [SmartThinQ Sensors](https://github.com/ollo69/ha-smartthinq-sensors) - LG appliances (washers, dryers, AC, fridges) wired up via SmartThinQ with rich state and remote start (1,296★).
 - [Home Connect Alt](https://github.com/ekutner/home-connect-hass) - Alternative Home Connect integration for Bosch, Siemens, NEFF, and Gaggenau ovens, dishwashers, and washing machines, with richer state than the official one (952★).
 - [Tapo Devices](https://github.com/petretiandrea/home-assistant-tapo-p100) - TP-Link Tapo plugs, switches, bulbs, and energy monitoring (P100, P105, P110, L510, L530, L900) over LAN (944★).
-- [Meross](https://github.com/albertogeniola/meross-homeassistant) - Meross plugs, switches, bulbs, garage door openers, and humidifiers via the Meross IoT cloud (846★).
+- [Meross](https://github.com/albertogeniola/meross-homeassistant) - Control Meross plugs, switches, bulbs, garage door openers, and humidifiers via the Meross IoT cloud (846★).
 - [HomeMatic IP Local](https://github.com/SukramJ/homematicip_local) - Local control of HomeMatic and HomeMatic IP devices through OpenCCU or RaspberryMatic, no cloud round-trips (564★).
-- [Nest Protect](https://github.com/iMicknl/ha-nest-protect) - Nest Protect smoke and CO alarms with battery state, recent events, and per-room safety status (456★).
+- [Nest Protect](https://github.com/iMicknl/ha-nest-protect) - Track Nest Protect smoke and CO alarms with battery state, recent events, and per-room safety status (456★).
 
 ### 🛠️ Automation tooling
 
@@ -326,9 +325,8 @@ _Helpers that make automations easier to write, debug, and maintain._
 _Local services that turn into sensors and calendars: garbage collection schedules, school holidays, traffic, weather alerts, and similar._
 
 - [Mail and Packages](https://github.com/moralmunky/Home-Assistant-Mail-And-Packages) - Sensors for incoming and delivered packages plus USPS Informed Delivery preview images, all from your existing email account (826★).
-- [Irrigation Unlimited](https://github.com/rgc99/irrigation_unlimited) - Irrigation controller with multi-zone schedules, sequences, weather adjustments, and manual run support (426★).
+- [Irrigation Unlimited](https://github.com/rgc99/irrigation_unlimited) - Multi-zone irrigation controller with schedules, sequences, weather adjustments, and manual run support (426★).
 - [Moonraker (Klipper)](https://github.com/marcolivierarsenault/moonraker-home-assistant) - Track Klipper-based 3D printers running Moonraker (Mainsail, Fluidd) with print progress, temperature, and webcam snapshots (462★).
-- [Afvalbeheer](https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer) - Garbage collection schedule sensors for many Dutch and Belgian municipalities, with paper, plastic, and organic streams broken out (368★).
 
 ### 🔐 Network & authentication
 
@@ -347,7 +345,7 @@ _Link multiple Home Assistant instances together, share entities across homes, o
 _Send Home Assistant data to external systems for long-term storage, richer dashboards, or analysis._
 
 - [Elasticsearch](https://github.com/legrego/homeassistant-elasticsearch) - Publishes events to Elasticsearch (164★).
-- [TrueNAS](https://github.com/tomaae/homeassistant-truenas) - TrueNAS Scale and TrueNAS Core stats, datasets, virtual machines, and apps surfaced as sensors and switches (364★).
+- [TrueNAS](https://github.com/tomaae/homeassistant-truenas) - Pull TrueNAS Scale and Core stats, datasets, virtual machines, and apps into sensors and switches (364★).
 - [Monitor Docker](https://github.com/ualex73/monitor_docker) - Watch CPU, memory, network, and uptime for every Docker container on a host, including remote ones, and start or stop them from automations (398★).
 
 ## Dashboard Cards
@@ -403,14 +401,14 @@ _Compact rows that pack more information into entity-card style listings._
 - [Battery State Card](https://github.com/maxwroc/battery-state-card) - List devices with their battery levels in a tidy card, sorted and color-coded (1,235★).
 - [Scheduler Card](https://github.com/nielsfaber/scheduler-card) - Build and edit weekly schedules for any entity right from the dashboard (1,220★).
 - [Entity Progress Card](https://github.com/francois-le-ko4la/lovelace-entity-progress-card) - Progress-bar card for any numeric entity, with thresholds, gradients, and templated icons (250★).
-- [Vehicle Status Card](https://github.com/ngocjohn/vehicle-status-card) - Vehicle dashboard card showing fuel or charge level, range, doors, lock state, and a customizable image of the car (251★).
+- [Vehicle Status Card](https://github.com/ngocjohn/vehicle-status-card) - Dashboard card showing fuel or charge level, range, doors, lock state, and a customizable image of the car (251★).
 
 ### ☀️ Weather cards
 
 _Weather widgets with the look you actually want._
 
 - [Weather Chart Card](https://github.com/mlamberts78/weather-chart-card) - Weather card with a chart-style hourly forecast and customizable layout (435★).
-- [Hourly Weather](https://github.com/decompil3d/lovelace-hourly-weather) - Hourly weather as a colored horizontal bar so you can see at a glance when conditions change today (387★).
+- [Hourly Weather](https://github.com/decompil3d/lovelace-hourly-weather) - Show today's hourly forecast as a colored horizontal bar so you can see at a glance when conditions change (387★).
 - [Weather Radar](https://github.com/Makin-Things/weather-radar-card) - Animated rain radar card using the public RainViewer tile service, with country-level and regional zoom (360★).
 
 ### 🎵 Media cards


### PR DESCRIPTION
## Summary

Adds 50 community projects sourced from the public HACS catalog, picking up where the earlier popular-HACS pass left off (PR #709).

## Methodology

- Pulled the HACS catalog (`integration`, `plugin`, `theme`) from `https://data-v2.hacs.xyz` and deduped against current `main`.
- Filtered by `last_updated` newer than 18 months, stars greater than or equal to 30, and ran HACS-as-bootstrap detection on integration descriptions.
- Sorted each kind by stars and shortlisted the top entries.
- Validated every shortlisted candidate via the GitHub REST API for: `archived: false`, `fork: false`, license in the allowlist (`mit, apache-2.0, agpl-3.0, gpl-2.0, gpl-3.0, lgpl-2.1, lgpl-3.0, bsd-2-clause, bsd-3-clause, isc, mpl-2.0, epl-2.0, 0bsd, unlicense`), and repo at least 6 months old.
- Classified each PASS into the most specific subsection in the README.

## Counts of additions per subsection

Custom Integrations (35):
- 🤖 AI & LLMs: 1
- 💡 Lighting: 1
- 🌡️ Climate: 2
- ⚡ Energy & solar: 6
- 📹 Cameras & video: 1
- 🚗 Cars & EV charging: 3
- 📍 Presence & location: 2
- 🏷️ Vendor & brand: 5
- 🛠️ Automation tooling: 5
- 🏘️ Civic & household: 4
- 🔐 Network & authentication: 1
- 📊 Logging & analytics: 2
- 🚨 Security & alarm, 🔊 Voice & media playback, 🧹 Vacuums, 🔵 Bluetooth & BLE, 🔋 Battery monitoring, 🔗 Federation & multi-instance: 0 (no qualifying candidates this round)

Dashboard Cards (15):
- 🧱 Dashboard frameworks: 1
- 📐 Layout helpers: 4
- 📈 Charts & graphs: 2
- 📋 Status & info rows: 2
- ☀️ Weather cards: 2
- 🌡️ Climate cards: 1
- ⚡ Energy cards: 1
- 💡 Lighting cards: 2
- 🧹 Vacuum cards: 1
- 📅 Calendar & feed: 1

Themes: 0 (no qualifying candidates passed validation).

## Notable judgment calls

- `UI-Lovelace-Minimalist/UI` describes itself as "a theme" but is a complete card collection / framework, so it is routed to Dashboard Cards / 🧱 Dashboard frameworks rather than Themes.
- `home-assistant-community-themes/midnight` was dropped because the existing "Midnight" theme entry already points at the same theme via its community.home-assistant.io thread.
- `WJDDesigns/Ultra-Vehicle-Card`, `r-renato/ha-card-weather-conditions`, `GeorgeSG/lovelace-time-picker-card`, `benjamin-dcs/gauge-card-pro` and a few other PASSes were trimmed from the shortlist purely to land on exactly 50 entries while keeping subsection diversity.
- `idaho/hassio-trash-card` is titled "Trash Card" in the entry to avoid the `Hass.io` abbreviation in our prose; the URL keeps the original repo name.

## Dropped candidates and why

License = `other` (NOASSERTION):
- `XiaoMi/ha_xiaomi_home`, `mampfes/hacs_waste_collection_schedule`, `Sian-Lee-SA/Home-Assistant-Switch-Manager`, `Limych/ha-average`, `dolezsa/thermal_comfort`, `alexpfau/calendar-card-pro`, `elax46/custom-brand-icons`, `pkissling/clock-weather-card`, `rianadon/timer-bar-card`

License missing entirely:
- `greghesp/ha-bambulab`, `jekalmin/extended_openai_conversation`, `slashback100/presence_simulation`, `SecKatie/ha-wyzeapi`, `ScratMan/HASmartThermostat`, `KoljaWindeler/ytube_music_player`, `binsentsu/home-assistant-solaredge-modbus`, `custom-components/nordpool`, `hasscc/hass-edge-tts`, `itchannel/fordpass-ha`, `flixlix/power-flow-card-plus`, `joseluis9595/lovelace-navbar-card`, `dbuezas/lovelace-plotly-graph-card`, `custom-cards/upcoming-media-card`, `AmoebeLabs/flex-horseshoe-card`, `KartoffelToby/better-thermostat-ui-card`, `dylandoamaral/uptime-card`, `azuwis/zigbee2mqtt-networkmap`, `AmoebeLabs/swiss-army-knife-card`, `xBourner/status-card`, `aFFekopp/noctis`, `home-assistant-community-themes/midnight`

Fork:
- `BJReplay/ha-solcast-solar`, `ollo69/ha-samsungtv-smart`, `rospogrigio/localtuya`, `kongo09/philips-airpurifier-coap`

Too new (less than 6 months):
- `3dg1luk43/ha_washdata` (created 2025-12-07, also `license=other`), `Giorgio866/lumina-energy-card` (created 2025-12-21)

Not found / repo unavailable at validation time:
- `rejuvenate/lovelace-horizon-card`, `punxaphil/custom-sonos-card`, `MelleD/lovelace-expander-card`

## Test plan

- [ ] `awesome-lint` and `lychee` workflows green on this PR
- [ ] `python scripts/check_listing.py <url>` green for each new entry (sample)
- [ ] Visual scan of new entries for voice rules (no `Home Assistant` in entry descriptions, no `HA`/`Hass`/`HASS`/`Hass.io`/`hassio` abbreviations in prose, no em or en dashes, no marketing fluff)
