### PR TITLE
Refresh new-item issue form to match current README taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/new.yml
+++ b/.github/ISSUE_TEMPLATE/new.yml
@@ -1,23 +1,21 @@
 name: 💖 Suggest a new item for the Awesome list
 title: "Add "
 labels: ["💖 new"]
-description: > 
-  I want to suggest a new item/resource/link to be added to the Home Assistant
-  Awesome list.
+description: >
+  I want to suggest a new item, resource, or link to be added to the
+  Awesome Home Assistant list.
 body:
   - type: markdown
     attributes:
       value: >
-        Cool! So you want to add a new link to the Home Assistant Awesomelist!
-        👌
+        Cool! So you want to add a new link to the Awesome Home Assistant
+        list! 👌
 
   - type: checkboxes
     attributes:
       label: New link requirements checklist
       description: >
-        This is boring, but important! Please make sure you read each
-        of these requirements to make sure the link you are suggesting meets
-        these.
+        Please make sure the link you are suggesting meets these requirements.
       options:
         - label: >-
             This is not self-promotion; I have not created or am affiliated
@@ -25,13 +23,15 @@ body:
           required: true
         - label: The link is widely recommended regardless of personal opinion.
           required: true
-        - label: Well known or discussed within the Community.
+        - label: Well known or discussed within the community.
           required: true
         - label: >-
-            Related to Home Assistant OR provide software, tools,
-            and utilities that can be used with Home Assistant.
+            Related to Home Assistant, or provides software, tools, hardware,
+            or content that can be used with Home Assistant.
           required: true
-        - label: Written in English.
+        - label: >-
+            Written in English (except entries proposed for the
+            "In your language" subsection).
           required: true
 
   - type: dropdown
@@ -39,20 +39,28 @@ body:
       required: true
     attributes:
       label: The category of the link
+      description: >
+        Pick the closest top-level section from the Awesome Home Assistant
+        list. The maintainer will route to the right subsection during
+        review.
       options:
+        - Custom Integration
+        - Dashboard Card
+        - Dashboard
+        - Theme
+        - Icon pack
         - App
-        - Alternative dashboard
+        - DIY project
+        - Tool or Utility
+        - Public Configuration
         - Blog
-        - Custom card
-        - Custom integration
-        - Discord/Slack/Chat community
-        - DIY
-        - Podcast
-        - Public configuration
-        - Themes
-        - Twitter/Facebook/TikTok/Instagram
         - YouTube Channel
-        - Other (Please leave a comment why)
+        - Podcast
+        - Social media account
+        - Community (help, chat, forum)
+        - Alternative Home Automation Software
+        - Other Awesome List
+        - Other (please leave a comment why)
 
   - type: input
     validations:
@@ -60,7 +68,8 @@ body:
     attributes:
       label: The name of the link
       description: >
-        The name of the link as it should be displayed in the Aweseome list.
+        The name of the link as it should be displayed in the Awesome
+        Home Assistant list.
 
   - type: input
     validations:
@@ -68,12 +77,14 @@ body:
     attributes:
       label: The description of the link
       description: >-
-        The description of of the link as shown in the Awesome list.
+        The description of the link as shown in the Awesome list.
 
         Some tips:
           - Keep the description short and simple, but descriptive.
-          - A description ends with a full stop/period `.`!
-          - Don't mention `Home Assistant` in the description as it's implied.
+          - A description ends with a full stop / period `.`.
+          - The description must not start with the item name (e.g. "Foo" → "A useful tool…", not "Foo is a useful tool…").
+          - Don't mention `Home Assistant` in the description as it is implied.
+          - Don't use abbreviations such as `HA`, `Hass`, or `Hass.io`.
           - Check your spelling and grammar.
 
   - type: input


### PR DESCRIPTION
## What

Refreshes `.github/ISSUE_TEMPLATE/new.yml` so the category dropdown reflects the README's actual structure.

## Why

The dropdown predates a chunk of the structural rework done this session and still asks contributors to pick from categories like "Custom card" or "Alternative dashboard" that no longer exist by those names, while leaving out new top-level sections (Icon packs, Tools & Utilities) entirely.

## Dropdown changes

| Before | After | Reason |
|---|---|---|
| App | App | unchanged |
| Alternative dashboard | Dashboard | renamed in #695 |
| Blog | Blog | unchanged |
| Custom card | **Dashboard Card** | renamed in #695 |
| Custom integration | Custom Integration | unchanged |
| Discord/Slack/Chat community | **Community (help, chat, forum)** | help section now has 4 subsections (#711) |
| DIY | **DIY project** | clarified |
| Podcast | Podcast | unchanged |
| Public configuration | Public Configuration | unchanged |
| Themes | **Theme** | unchanged (de-pluralised) |
| Twitter/Facebook/TikTok/Instagram | **Social media account** | rolled up |
| YouTube Channel | YouTube Channel | unchanged |
| Other (Please leave a comment why) | Other (please leave a comment why) | unchanged |
| **(missing)** | **Icon pack** | added; Icon packs is a top-level section |
| **(missing)** | **Tool or Utility** | added; Tools & Utilities is a top-level section |
| **(missing)** | **Alternative Home Automation Software** | added |
| **(missing)** | **Other Awesome List** | added |

The dropdown stays at top-level only — flattening every subsection (Custom Integrations alone has 18) would balloon to 50+ entries. The PR description note explains the maintainer routes to the right subsection during review.

## Other tightening

- Reworded the intro and checklist to remove the typo "Awesomelist" and the duplicated "of of".
- Loosened the "Written in English" requirement to acknowledge the new "In your language" subsection.
- Added two description tips for the rules contributors most commonly miss:
  - **Do not start the description with the item name** (the rule that bit batch 2)
  - **Do not use HA / Hass / Hass.io abbreviations** in description prose

## Not changed

- `.github/ISSUE_TEMPLATE/remove.yml` and `update.yml` only ask for a URL plus reason; nothing in those forms references the old taxonomy.
- `.github/ISSUE_TEMPLATE/z-other.yml` is the catch-all and stays generic.
- `.github/ISSUE_TEMPLATE/config.yml` is just `blank_issues_enabled: false` and stays.

## Test plan

- [ ] Visit `https://github.com/frenck/awesome-home-assistant/issues/new/choose` after merge and confirm the new dropdown renders cleanly.
- [ ] Spot-check that submitting a "💖 new" issue still attaches the right label.
