### PR TITLE
Add C-Gate Web Bridge to Third Party Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ _Anyone can create an app, the following are created by the community._
 - [Hass.io Google Drive Backup](https://github.com/sabeechen/hassio-google-drive-backup) - A complete and easy-to-configure solution for backing up to Google Drive (3,537★).
 - [Grocy](https://github.com/hassio-addons/app-grocy) - ERP beyond your fridge! A groceries & household management solution for your home (429★).
 - [CrowdSec](https://github.com/crowdsecurity/home-assistant-addons) - A next-gen collaborative IPS/IDS to protect you from intrusion (94★).
+- [C-Gate Web Bridge](https://github.com/dougrathbone/cgateweb-homeassistant) - Bridge Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT with auto-discovery (4★).
 
 ## DIY
 


### PR DESCRIPTION
## Add-on

[C-Gate Web Bridge](https://github.com/dougrathbone/cgateweb-homeassistant) — bridges Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT with auto-discovery.

## What it does

Connects to a [C-Gate](https://updates.clipsal.com/ClipsalSoftwareDownload/mainsite/cis/technical/downloads/index.html) server (Clipsal's C-Bus gateway software) and bridges C-Bus devices to Home Assistant using MQTT Discovery. Supports:

- **Lights** (dimmable, via C-Bus Application 56)
- **Covers** (blinds, shutters, garage doors)
- **Switches and relays**
- **HVAC/climate zones**
- **Trigger groups** (keypads, scenes)
- **PIR sensors**

Features connection pooling, automatic MQTT broker detection from the Mosquitto add-on, and a built-in label editor web UI.

## Acceptance-criteria notes

- **License**: the linked add-on repo (`dougrathbone/cgateweb-homeassistant`) is now released under the MIT License — GitHub's licensee detection confirms `mit` (this was the blocker on #657 and is now resolved). The source repo (`dougrathbone/cgateweb`) is also MIT.
- **Stars (soft warning)**: the add-on repo currently has 4 stars. C-Bus is a niche, region-specific (largely AU/NZ/EU commercial-installation) lighting protocol — this fills a gap for the small but active community of Home Assistant users with C-Bus installations who currently have no first-class HA bridge for their hardware.
- **Age**: source repo created 2021-07; distribution repo created 2025-09. Both pushed today.
- **HA mention**: dist-repo README opens with *"A Home Assistant add-on that bridges Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT."*

## Links

- **Add-on repository:** https://github.com/dougrathbone/cgateweb-homeassistant
- **Source code:** https://github.com/dougrathbone/cgateweb
- **C-Bus by Clipsal:** https://www.clipsal.com/products/c-bus

Replaces #657, which was closed pending the LICENSE addition.