### PR TITLE
Fix contributing footer link to use x.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ This awesome list is an active open-source project and is always open to
 people who want to contribute to it. We have set up a separate document
 containing our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
 
-The original setup of this awesome list is by [Franck Nijhof](https://twitter.com/frenck).
+The original setup of this awesome list is by [Franck Nijhof](https://x.com/frenck).
 
 For a full list of all authors and contributors, check the
 [contributor's page](https://github.com/frenck/awesome-home-assistant/graphs/contributors).


### PR DESCRIPTION
## Summary

- Updates the Franck Nijhof link in the Contributing footer from `twitter.com/frenck` to `x.com/frenck`.

## Test plan

- [ ] Link checker passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)