### PR TITLE
Add HA Linux Companion to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editing your configuration.
 - [Mi Flora via MQTT daemon](https://github.com/ThomDietrich/miflora-mqtt-daemon) - Collect and transfer Xiaomi Mi Flora plant sensor data via MQTT (623★).
 - [Home Assistant Taskbar Menu](https://github.com/PiotrMachowski/Home-Assistant-Taskbar-Menu) - A client for Windows that can display Lovelace views, control entities and show persistent notifications (342★).
+- [HA Linux Companion](https://github.com/SimoneB79/ha-linux-companion) - Electron-based companion app for Raspberry Pi and Linux touch panels, with Lovelace dashboard, system sensors, hardware controls, and real-time notifications.
 
 ## Online Resources
 


### PR DESCRIPTION
## Addition

Added **HA Linux Companion** to the Tools & Utilities section.

### What it is

[HA Linux Companion](https://github.com/SimoneB79/ha-linux-companion) is an Electron-based companion app for Raspberry Pi and Linux touch panels. It turns a Raspberry Pi with a touchscreen into a dedicated Home Assistant wall panel.

### Features

- Lovelace dashboard in kiosk mode via Electron
- System sensors (CPU temp, CPU%, RAM%, disk%, uptime, IP, display state) published via mobile_app webhook
- Hardware controls overlay (volume, brightness, bluetooth)
- WebSocket real-time notifications
- On-screen virtual keyboard for touch panels
- Full auth flow (username/password + 2FA + long-lived token)
- mobile_app device registration with webhook
- Systemd service for auto-start
- Supports self-signed certificates

### Why it fits

It complements the existing "Home Assistant Taskbar Menu" (Windows client) entry as a Linux/Raspberry Pi counterpart. Many community members repurpose Raspberry Pis with touchscreens as wall-mounted Home Assistant panels — this project provides a purpose-built solution for that use case.