### PR TITLE
Add Govee Cloud integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ _Pull a specific manufacturer's devices into Home Assistant, often with more fea
 - [Home Connect Local](https://github.com/chris-mc1/homeconnect_local_hass) - Talks to Bosch, Siemens, NEFF, and Gaggenau appliances directly over the local network, no cloud detour (373★).
 - [hOn](https://github.com/gvigroux/hon) - Pulls Haier, Candy, and Hoover appliances from the official hOn cloud, exposing every state and parameter the app shows (249★).
 - [PETLIBRO](https://github.com/jjjonesjr33/petlibro) - Adds PETLIBRO smart pet feeders and fountains, with feeding schedules, dispense events, and battery levels (309★).
+- [Govee Cloud](https://github.com/lasswellt/govee-homeassistant) - Cloud control of Govee lights, RGBIC strips, plugs, fans, humidifiers, heaters, thermometers, and leak sensors, with real-time updates over Govee's AWS IoT push (57★).
 
 ### 🛠️ Automation tooling
 


### PR DESCRIPTION
## Adding a custom integration

**[Govee Cloud](https://github.com/lasswellt/govee-homeassistant)** — added to **Custom Integrations → 🏷️ Vendor & brand**.

Cloud control of Govee lights, RGBIC strips (incl. per-segment color), plugs, fans, humidifiers, heaters, thermometers, and leak sensors via the Govee API v2.0, with optional **real-time push over Govee's AWS IoT MQTT** (not just polling). Capability-based (no hard-coded SKU list), UI-only config, HA quality scale **silver**, actively maintained (latest release v2026.6.3).

### Checklist
- [x] Repository is public, has a description, topics, and a README
- [x] OSI-approved license (Apache-2.0)
- [x] Repo is older than 6 months and pushed to recently
- [x] Valid `hacs.json` + `manifest.json`; passes HACS Action + Hassfest CI
- [x] Single addition, alphabetized within its bullet group / placed by the section's convention
- [x] One entry, one line, with star count

### Note for maintainers
The existing **💡 Lighting → Govee** entry points to [`LaggAt/hacs-govee`](https://github.com/LaggAt/hacs-govee), which is now effectively unmaintained (maintainer seeking a handoff; 150+ open issues; last release a compat-only build). This new entry is a separate, actively-maintained vendor-wide integration — happy to adjust placement or wording to fit the list's conventions.