### PR TITLE
Add Fistacho/ha-nexus-agent to AI & LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ _Wire Home Assistant up to a large language model and let it read your devices, 
 
 - [LLM Vision](https://github.com/valentinfrlch/ha-llmvision) - Add visual intelligence to your automations: caption camera snapshots, summarize what is happening, react to specific events (1,373★).
 - [AI Automation Suggester](https://github.com/ITSpecialist111/ai_automation_suggester) - Scan your entities and ask an AI provider (OpenAI, Anthropic, Google, Groq, Ollama) for tailored automation suggestions, surfaced as notifications (749★).
+- [Nexus Agent](https://github.com/Fistacho/ha-nexus-agent) - MCP server giving AI assistants (Claude, Cursor, VS Code, Windsurf, Gemini CLI) full control over your smart home: 285 tools across 27 domains — entities, automations, dashboards, HACS, Supervisor, Card Builder, git versioning, and more. Ships as a one-click HA add-on (11★).
 
 ### 💡 Lighting
 


### PR DESCRIPTION
Adds [Fistacho/ha-nexus-agent](https://github.com/Fistacho/ha-nexus-agent) to the **🤖 AI & LLMs** section.

MCP server for Home Assistant — gives AI assistants (Claude, Cursor, VS Code, Windsurf, Gemini CLI) full control over your smart home via 285 tools across 27 domains: entities, automations & scripts (CRUD + traces + linter + live reference validator), dashboards (+ screenshot), blueprints, calendar, HACS, Supervisor, energy, voice pipelines, Card Builder, BM25 tool search, git versioning, and more.

Ships as a one-click HA add-on — open the web UI, copy the generated MCP config, paste into your AI client.

- License: MIT
- Latest release: v0.16.0