### PR TITLE
Add conf-edit-ha to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [ADB Intents](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304) - List of ADB intents to control Android Devices.
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editing your configuration.
 - [Home Assistant Taskbar Menu](https://github.com/PiotrMachowski/Home-Assistant-Taskbar-Menu) - A client for Windows that can display Lovelace views, control entities and show persistent notifications (342★).
+- [conf-edit-ha](https://github.com/roman-pinchuk/conf-edit-ha) - Lightweight web-based text editor for configuration files with YAML syntax highlighting and entity autocomplete.
 
 ## Online Resources
 


### PR DESCRIPTION
Adding [conf-edit-ha](https://github.com/roman-pinchuk/conf-edit-ha), a lightweight web-based text editor for Home Assistant configuration files, to the Tools & Utilities section.

### ✅ Acceptance Criteria Checklist

I have verified that `conf-edit-ha` meets the following requirements:

- [x] **URL Accessibility:** The URL is reachable, uses HTTPS, and is not a shortener.
- [x] **No Tracking:** Common tracking parameters have been stripped from the URL.
- [x] **Unique Entry:** The URL is not already listed elsewhere in the README.
- [x] **Active Repository:** The repository is not archived and has been pushed to within the last 18 months.
- [x] **Documentation:** There is a `README.md` at the repository root that mentions "Home Assistant".
- [x] **Open-Source:** Released under an OSI-approved open-source license (MIT).
- [x] **HACS JSON:** *N/A (This is a Supervisor Add-on, not a custom integration/card).*

### ⚠️ Note for Reviewers
- **Repository Age:** The repository was created on January 9, 2026 (~5.5 months ago). I realize the guidelines require a 6-month minimum age, but I am submitting this slightly early for visibility. Please let me know if this needs to wait until July 9th.
