### PR TITLE
Add Tesserae to DIY > Standalone projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ _Some of the best smart-home gadgets do not exist as products you can buy, but o
 - [Tasmota](https://github.com/arendst/Tasmota) - Firmware for ESP8266 boards and devices (24,475★).
 - [Sonoff NSPanel](https://github.com/joBr99/nspanel-lovelace-ui) - Custom firmware for Sonoff NSPanel touchscreens with a Lovelace-style UI (988★).
 - [CODESYS V3 Home Automation](https://github.com/MichielVanwelsenaere/HomeAutomation.CoDeSys3) - PLC home-automation software that communicates over MQTT for wired automation setups (144★).
+- [Tesserae](https://github.com/dmellok/tesserae) - Self-hosted dashboard server that pushes composed tile frames to e-ink panels (Pi, ESP32, jailbroken Kindle, TRMNL) with MQTT auto-discovery, webhook push, and an HA App in the official add-on store (134★).
 
 ### 🌉 DIY Gateways
 


### PR DESCRIPTION
## What's being added

[Tesserae](https://github.com/dmellok/tesserae), a self-hosted dashboard server that composes tile layouts in the browser and pushes rendered frames to e-ink panels driven by Raspberry Pi, ESP32, jailbroken Kindle (via the TRMNL BYOS protocol), and native TRMNL devices.

Slotted into **DIY → 🧩 Standalone projects**, alongside ESPHome, Tasmota, Sonoff NSPanel and CODESYS V3. Like those, Tesserae is a standalone server you run next to Home Assistant rather than an integration installed through HACS.

## Why it fits

- **HA App in the official add-on store** — installable from the Add-on Store like any other supervisor add-on.
- **MQTT auto-discovery** — every Tesserae device (panel battery, signal strength, last-paint time, per-device preview camera entity) auto-creates in HA without manual YAML.
- **Webhook push** — HA automations can call `POST /api/v1/push` with a bearer token to re-render and fan a dashboard out to every bound device. Useful for "show the calendar when the morning alarm fires", "swap to weather radar when it starts raining", etc.
- **Multi-device by design** — one server drives multiple panels (Pi, ESP32-based boards including Pimoroni Inky and Waveshare Spectra 6, jailbroken Kindle, native TRMNL), each bound to a different dashboard.
- **Drop-a-folder plugin model** for widgets, renderers, and devices — adding a new panel kind or widget is a contained change, not a fork.

## Resources

- Documentation: https://dmellok.github.io/tesserae/
- Home Assistant integration guide: https://dmellok.github.io/tesserae/install/home-assistant/
- Widget gallery: https://dmellok.github.io/tesserae/widgets/gallery/
- Current release: [v0.64.8](https://github.com/dmellok/tesserae/releases/latest)
- Licence: AGPL-3.0-or-later

## Compliance

Description follows the section's existing style (one sentence, star count suffix). Inserted at the end of the standalone-projects subsection matching the existing addition-order pattern.
