### PR TITLE
Add Humidity Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ _Smarter thermostats, comfort sensors, and HVAC integrations that go beyond what
 - [Midea Air Appliances LAN](https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan) - Local control of Midea air conditioners, dehumidifiers, and other appliances over LAN (460★).
 - [Smart Autotune Thermostat (SAT)](https://github.com/Alexwijn/SAT) - Self-tuning thermostat that talks to OpenTherm, ESPHome, or MQTT gateways and adapts the heating curve to your home over time (246★).
 - [Dual Smart Thermostat](https://github.com/swingerman/ha-dual-smart-thermostat) - Enhanced version of the built-in generic thermostat, with separate heating and cooling, floor temperature limits, and humidity controls (225★).
+- [Humidity Intelligence](https://github.com/senyo888/humidity-intelligence) - seasonal aware environmental Stabilisation of humidity, condensation, mould risk, air quality, and comfort with explainable control decisions.
 
 ### ⚡ Energy & solar
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ _Smarter thermostats, comfort sensors, and HVAC integrations that go beyond what
 - [Midea Air Appliances LAN](https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan) - Local control of Midea air conditioners, dehumidifiers, and other appliances over LAN (460★).
 - [Smart Autotune Thermostat (SAT)](https://github.com/Alexwijn/SAT) - Self-tuning thermostat that talks to OpenTherm, ESPHome, or MQTT gateways and adapts the heating curve to your home over time (246★).
 - [Dual Smart Thermostat](https://github.com/swingerman/ha-dual-smart-thermostat) - Enhanced version of the built-in generic thermostat, with separate heating and cooling, floor temperature limits, and humidity controls (225★).
-- [Humidity Intelligence](https://github.com/senyo888/humidity-intelligence) - seasonal aware environmental Stabilisation of humidity, condensation, mould risk, air quality, and comfort with explainable control decisions.
+- [Humidity Intelligence](https://github.com/senyo888/humidity-intelligence) - Season-aware environmental control for humidity, condensation, mould risk, air quality, and comfort with explainable decisions.
 
 ### ⚡ Energy & solar
 


### PR DESCRIPTION
Added a new project link for Humidity Intelligence with a brief description.

# Describe the proposed change

This PR adds [Humidity Intelligence](https://github.com/senyo888/humidity-intelligence) to the Climate section.

Humidity Intelligence is a HACS custom integration for stabilising humidity, condensation, mould risk, air quality, and comfort with explainable control decisions.

This is a resubmission of #718. The previous PR was closed because the repository had not yet reached the required age threshold. That age gate has now elapsed.

Disclosure: I maintain the project.

## The link


- https://github.com/senyo888/humidity-intelligence - Stabilises humidity, condensation, mould risk, air quality, and comfort with explainable control decisions.

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [x] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [x] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).

---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
