### PR TITLE
Add Beatify to Voice & media playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ _Send commands to voice speakers and media players, or relay what they hear and 
 - [YandexStation](https://github.com/AlexxIT/YandexStation) - Control Yandex Station speakers and other smart-home devices through Alice (1,868★).
 - [Yandex Smart Home](https://github.com/dext0r/yandex_smart_home) - Expose your devices to Yandex Alice and the Yandex smart-home app (1,066★).
 - [View Assist Companion](https://github.com/msp1974/ViewAssist_Companion_App) - Companion Android app and integration that turns a tablet into a hands-free voice and dashboard satellite (374★).
+- [Beatify](https://github.com/mholzi/beatify) - Music year-guessing party game where players scan a QR code, hear a song and guess its release year, with playback through Music Assistant, Sonos or Alexa speakers (218★).
 
 ### 🚗 Cars & EV charging
 


### PR DESCRIPTION
## Add Beatify

[Beatify](https://github.com/mholzi/beatify) is a music year-guessing party game for the living room: players scan a QR code with their phones, a song plays on the household speakers, and everyone guesses the release year. Playback runs through Music Assistant, so Sonos, Alexa and Chromecast speakers all work.

### This is a re-submission you invited

PR #639 was closed on 2026-01-30 by @frenck for one reason only — the 6-month minimum repository age. The closing comment said:

> Please open a fresh PR after **2026-06-18** and we'll be happy to take another look.

`mholzi/beatify` was created 2025-12-18 and is now **7.5 months old**, so that bar is met. Nothing else about the earlier PR was objected to; this one is a single-line addition in the same spirit.

### Self-promotion disclosure

**I am the author of the linked repository.** CONTRIBUTING.md asks for an explanation in that case, so here it is, without overselling:

- The project is **not** widely known. It has 218 stars and roughly 420 active installations reported by HA Analytics (rank ~470 of 4,209 custom integrations — the top 11%, not the top 1%).
- What I think earns it a slot is that it fills a gap the list currently has none of: there is no party-game or "fun" entry among the custom integrations, and nothing else that turns an existing Music Assistant setup into a group activity.
- If the maintainers judge that "widely recommended" is not yet met, I would rather have that said plainly than have the entry slipped in. Closing this is a fine outcome.

### Checks

`scripts/check_listing.py --base origin/main` passes — all checks green.

| Criterion | Status |
|---|---|
| Repository age ≥ 6 months | 7.5 months (created 2025-12-18) |
| Not archived, pushed recently | pushed today |
| OSI license | MIT |
| README at root, mentions Home Assistant | yes (36 mentions) |
| `hacs.json` + `custom_components/beatify/manifest.json` | both present |
| Stars ≥ 10 | 218 |
| URL hygiene | HTTPS, canonical, no tracking params |
| Placement | last item in its category |
| Description | does not start with the name, no "Home Assistant", ends with a period |

### Section choice

**Custom Integrations › 🔊 Voice & media playback.** Per AGENTS.md the taxonomy is structural rather than topical, and Beatify is a custom integration that drives media players. There is no games/entertainment subsection; if you would rather see one, or prefer this elsewhere, say so and I will move it.