### PR TITLE
Remove dead link: DIY Futurism

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,7 +696,6 @@ _Home Assistant has a thriving community of bloggers, YouTubers, podcasters, and
 
 #### English
 
-- [DIY Futurism](https://diyfuturism.com/) - Articles with clear step-by-step instructions for new users by Brad.
 - [Smart Home Hobby](https://smarthomehobby.com/) - Features budget-friendly guides and information.
 - [Self Hosted Home](https://selfhostedhome.com/) - Articles on DIY home automation projects and self-hosted services.
 - [Tinkering with Home Automation](https://blog.ceard.tech/) - Tinkerer's blog and guides.


### PR DESCRIPTION
`https://diyfuturism.com/` (Online Resources → Blogs) is unreachable — the server does not respond (connection reset / timeout; DNS still resolves but no HTTP response). This is the link Lychee has been flagging on PRs. Removing it so CI goes green again; happy to re-add if the site comes back online.