### PR TITLE
Add PadSpan HA to Bluetooth & BLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ _Pull data from sensors that broadcast over Bluetooth, or use Bluetooth itself f
 - [Bermuda](https://github.com/agittins/bermuda) - Room-level presence detection by triangulating BLE signals across multiple ESPHome receivers (1,798★).
 - [BLE Battery Management Systems](https://github.com/patman15/BMS_BLE-HA) - Reads Bluetooth Low Energy battery management systems (BMS) from many vendors, exposing per-cell voltages, balancing, and SOC (328★).
 - [EcoFlow BLE](https://github.com/rabits/ha-ef-ble) - Pulls EcoFlow power stations and accessories over Bluetooth Low Energy, no cloud account required (304★).
+- [PadSpan HA](https://github.com/gbroeckling/padspanHA) - Room-level BLE presence tracking with 3D floor plan visualization, calibration tools, follow mode, and 21 dashboard views (179★).
 
 ### 🔋 Battery monitoring
 


### PR DESCRIPTION
Resubmission of #648, which was closed on 2026-05-08 for two blockers:

1. Repository age (~92 days at the time, under the 6-month minimum). It is now 6+ months old (created 2026-02-05).
2. LICENSE reported `NOASSERTION`, not OSI-approved. A full GPL-3.0 license file was added 2026-07-14; `gh api repos/gbroeckling/padspanHA --jq .license.spdx_id` now returns `GPL-3.0`.

`scripts/check_listing.py` passes with no errors or warnings for this entry.

Self-promotion note: I am the author of PadSpan HA (`gbroeckling`), flagged per the CI self-promotion check. It's a BLE room-presence tracker (room-level tracking, 3D floor plans, calibration, follow mode) with 179 stars and has been merged into hacs/default (installable via HACS), which is why I think it clears the "widely recommended" bar for the Bluetooth & BLE section alongside Bermuda.