### PR TITLE
Add home-mind to Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [ADB Intents](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304) - List of ADB intents to control Android Devices.
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editing your configuration.
 - [Home Assistant Taskbar Menu](https://github.com/PiotrMachowski/Home-Assistant-Taskbar-Menu) - A client for Windows that can display Lovelace views, control entities and show persistent notifications (342★).
+- [home-mind](https://github.com/hoornet/home-mind) - Self-hosted memory layer for your voice assistant: remembers household facts across conversations, reinforces the ones you use, and forgets on request (89★).
 
 ## Online Resources
 

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [ADB Intents](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304) - List of ADB intents to control Android Devices.
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editing your configuration.
 - [Home Assistant Taskbar Menu](https://github.com/PiotrMachowski/Home-Assistant-Taskbar-Menu) - A client for Windows that can display Lovelace views, control entities and show persistent notifications (342★).
-- [home-mind](https://github.com/hoornet/home-mind) - Self-hosted memory layer for your voice assistant: remembers household facts across conversations, reinforces the ones you use, and forgets on request (89★).
+- [Home Mind](https://github.com/hoornet/home-mind) - Self-hosted memory layer for Assist: remembers household facts across conversations, reinforces the ones you use, and forgets on request (89★).
 
 ## Online Resources
 

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [ADB Intents](https://gist.github.com/mcfrojd/9e6875e1db5c089b1e3ddeb7dba0f304) - List of ADB intents to control Android Devices.
 - [Home Assistant Config Helper for VSCode](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) - Visual Studio Code Extension that provides auto-completion, config validation and snippets when editing your configuration.
 - [Home Assistant Taskbar Menu](https://github.com/PiotrMachowski/Home-Assistant-Taskbar-Menu) - A client for Windows that can display Lovelace views, control entities and show persistent notifications (342★).
-- [Home Mind](https://github.com/hoornet/home-mind) - Self-hosted memory layer for Assist: remembers household facts across conversations, reinforces the ones you use, and forgets on request (89★).
+- [Home Mind](https://github.com/hoornet/home-mind) - Self-hosted memory layer for Assist: remembers household facts across conversations, reinforces the ones you use, and forgets on request.
 
 ## Online Resources
 


### PR DESCRIPTION
This is my own project, so per the contribution guidelines, the case for it:

home-mind is a self-hosted AGPL server that gives Assist conversations persistent memory — facts about the household are remembered across conversations, reinforced when used, and can be deleted by asking in plain language. It sits alongside Home Assistant (Docker Compose) and connects through a companion integration, which is why I'm proposing Tools & Utilities rather than Custom Integrations.

On the acceptance bar: 89 stars since January 2026, actively maintained (v0.16.2 released this week), and the issue tracker shows real community usage rather than just my own. Memory for voice assistants is a gap the ecosystem is actively discussing, and this is one of the few self-hostable answers to it.

Happy to adjust wording or placement if the maintainers see a better fit.