### PR TITLE
Add esp32-nut to DIY Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ _Some of the best smart-home gadgets do not exist as products you can buy, but o
 - [Home Assistant's Hackster.io](https://www.hackster.io/home-assistant?f=1#_=_) - A Hackster channel with multiple DIY projects.
 - [Bed Presence Detection](https://selfhostedhome.com/diy-bed-presence-detection-home-assistant/) - ESP8266 based Bed Presence Detection.
 - [QuinLED](https://quinled.info/) - DIY Wi-Fi LED dimmers and controllers using ESP32 boards.
+- [esp32-nut](https://github.com/maverick1982/esp32-nut) - Wi-Fi bridge that connects any USB UPS directly to the Home Assistant NUT integration using a $5 ESP32-S3.
 
 ## Tools & Utilities
 


### PR DESCRIPTION
I would like to submit esp32-nut to the DIY Projects section. 

 esp32-nut solves a common pain point for Home Assistant users: monitoring a USB UPS that isn't physically close to the HA server. Instead of setting up a dedicated Raspberry Pi or running long USB cables, this open-source firmware turns a cheap ESP32-S3 into a standalone NUT (Network UPS Tools) server. 

 It reads HID data directly from the UPS via USB and exposes it over Wi-Fi, allowing the native Home Assistant NUT integration to connect to it seamlessly.

# Describe the proposed change

Describe the change and rationale behind them. In case of a new link be, please describe what the link provides and why it is awesome!

## The link

Add the link here.

## The annoying "I agree" thing

**PRO TIP!** _Don't check the boxes right now! Open the PR first, and it will allow you actually to check the boxes using simple mouse clicks._

- [ ] Check this box if you have read, understand, comply, and agree with our [Code of Conduct](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CODE_OF_CONDUCT.md).

- [ ] Check this box if you have read, understand, and comply with our [Contribution Guidelines](https://github.com/frenck/awesome-home-assistant/blob/main/.github/CONTRIBUTING.md).
---
Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach significant numbers.
