### PR TITLE
Add ble-scale-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ _Anyone can create an app, the following are created by the community._
 - [Grocy](https://github.com/hassio-addons/app-grocy) - ERP beyond your fridge! A groceries & household management solution for your home (433★).
 - [CrowdSec](https://github.com/crowdsecurity/home-assistant-addons) - A next-gen collaborative IPS/IDS to protect you from intrusion (94★).
 - [C-Gate Web Bridge](https://github.com/dougrathbone/cgateweb-homeassistant) - Bridge Clipsal C-Bus lighting and automation systems to Home Assistant via MQTT with auto-discovery (4★).
+- [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Reads weight and body composition from 25+ Bluetooth smart scales and publishes every metric over MQTT with auto-discovery (153★).
 
 ## DIY
 


### PR DESCRIPTION
Adds [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) as the last item under Apps > Third Party Apps.

Re-submission of #642, which was closed on the 6-month repository-age rule with an invitation to return after 2026-07-13. The repo was created 2026-01-13, so it is now 7 months old.

**What it is:** a headless bridge that reads weight and body composition (fat %, muscle mass, bone mass, water %, BMR, visceral fat and more) from 25+ Bluetooth smart scale brands, and publishes all 11 metrics over MQTT with auto-discovery. Sensors appear automatically as one grouped device, with LWT availability and per-metric display precision. Multi-user support matches a reading to the right person by weight, so a shared scale produces separate device entries.

It ships as an installable app via its own repository (`repository.yaml` + `ble-scale-sync-addon/`), with MQTT credentials auto-detected through the Supervisor API, which is why Third Party Apps is the right section rather than DIY.

**Acceptance criteria:**

- Not archived, actively developed (v1.23.0 released 2026-08-19, releases roughly monthly).
- Created 2026-01-13, over 6 months old.
- `README.md` at the repository root, in English.
- GPL-3.0, OSI-approved.
- 153 stars, well above the 10-star soft bar.
- README mentions Home Assistant.
- Documentation site: https://blescalesync.dev

**Self-promotion disclosure:** I am the author, so CI will flag this. The case for inclusion: there was no open-source way to get a generic BLE body-composition scale into Home Assistant without the vendor cloud app. It covers 30 protocol adapters across brands such as Xiaomi, Renpho, Beurer, Eufy, QN, Yunmai and Arboleaf, works over built-in Bluetooth, an ESPHome BLE proxy, or an ESP32/MQTT proxy, and about 20 of the supported scales were added from user-submitted captures. There is also a community Home Assistant integration built on top of it ([JustBeanie/ble-scale-hass](https://github.com/JustBeanie/ble-scale-hass)).