### PR TITLE
Add Hardware Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ _Helpers, daemons, and developer tools that sit alongside Home Assistant rather 
 - [HASS Configurator](https://github.com/danielperna84/hass-configurator) - Browser-based configuration file editor (334★).
 - [HA-Dockermon](https://github.com/philhawthorne/ha-dockermon) - A Node.js service for RESTful switches to control Docker containers (291★).
 - [Home Assistant Device Database](https://www.hadevices.com/) - Database of supported/confirmed working devices.
+- [Hardware Matrix](https://hardwarematrix.dev/) - Compatibility index of 177 sensor and microcontroller pairings with validated ESPHome configurations and an open CC BY-SA dataset.
 - [Jinja Scripts for Curious Minds](https://github.com/skalavala/mysmarthome/tree/master/jinja_helpers) - Bunch of Jinja2 scripts helping you to understand it better.
 - [GitLab CI/CD](https://about.gitlab.com/2018/08/02/using-the-gitlab-ci-slash-cd-for-smart-home-configuration-management/) - How to simplify your smart home configuration with GitLab CI/CD.
 - [Monitor](https://github.com/andrewjfreyer/monitor) - Distributed advertisement-based BTLE presence detection reported via MQTT (2,104★).


### PR DESCRIPTION
Adds Hardware Matrix to Tools & Utilities, next to the existing device-database entry.

It is a compatibility index of 177 sensor/microcontroller pairings (ESP32, ESP8266, Pico W and friends), where each pairing documents the verdict, wiring, I2C address conflicts and a curated ESPHome configuration that is validated against the ESPHome CLI before publishing. The underlying dataset is downloadable as CSV/JSON under CC BY-SA 4.0.

Disclosure: this is my own project.

Checklist per the contribution guide: one link, HTTPS, no tracking parameters, description ends with a period and does not name Home Assistant.
